### PR TITLE
v2.0.4: Bug fixes, test coverage, and file size limit

### DIFF
--- a/WebFiori/File/File.php
+++ b/WebFiori/File/File.php
@@ -976,19 +976,28 @@ class File implements JsonI {
         if ($this->isExist()) {
             $fSize = filesize($fPath);
             $this->setSize($fSize);
-            $bytesToRead = $to - $from > 0 ? $to - $from : $this->getSize();
-            $resource = self::createResource('rb', $fPath);
 
-            if ($bytesToRead > $this->getSize() || $to > $this->getSize()) {
+            if ($from === -1 && $to === -1) {
+                $bytesToRead = $fSize;
+                $from = 0;
+            } else {
+                $from = max($from, 0);
+
+                if ($to === -1) {
+                    $to = $fSize;
+                }
+                $bytesToRead = $to - $from;
+            }
+
+            if ($bytesToRead > $fSize || $to > $fSize) {
                 throw new FileException('Reached end of file while trying to read '.$bytesToRead.' byte(s).');
             }
+
+            $resource = self::createResource('rb', $fPath);
 
             if (is_resource($resource)) {
                 if ($bytesToRead > 0) {
                     fseek($resource, $from);
-                }
-
-                if ($bytesToRead > 0) {
                     $this->rawData = fread($resource, $bytesToRead);
                 }
                 fclose($resource);

--- a/WebFiori/File/File.php
+++ b/WebFiori/File/File.php
@@ -92,7 +92,7 @@ class File implements JsonI {
         self::initErrHandler();
 
         if (!$this->setPath($fPath)) {
-            $info = $this->extractPathAndName($fNameOrAbsPath);
+            $info = self::extractPathAndName($fNameOrAbsPath);
             $this->setDir($info['path']);
             $this->setName($info['name']);
         } else {
@@ -936,7 +936,7 @@ class File implements JsonI {
      * 
      * @return array An associative array with 'path' and 'name' keys.
      */
-    private function extractPathAndName($absPath): array {
+    public static function extractPathAndName(string $absPath): array {
         $DS = DIRECTORY_SEPARATOR;
         $cleanPath = str_replace('\\', $DS, str_replace('/', $DS, trim($absPath)));
         $pathArr = explode($DS, $cleanPath);

--- a/WebFiori/File/File.php
+++ b/WebFiori/File/File.php
@@ -85,7 +85,7 @@ class File implements JsonI {
      */
     public function __construct(string $fNameOrAbsPath = '', string $fPath = '') {
         $this->mimeType = self::DEFAULT_MIME;
-        $this->fileSize = -1;
+        $this->fileSize = null;
         $this->path = '';
         $this->fileName = '';
         $this->rawData = '';
@@ -470,19 +470,19 @@ class File implements JsonI {
     /**
      * Returns the size of the file in bytes.
      *
-     * @return int Size of the file in bytes. If the raw data of the file
-     * is not set or the file does not exist, the method will return -1.
+     * @return int|null Size of the file in bytes. If the raw data of the file
+     * is not set or the file does not exist, the method will return null.
      */
-    public function getSize() : int {
+    public function getSize() : ?int {
         return $this->fileSize;
     }
     /**
      * Checks if the file has a known size.
      *
-     * @return bool True if the file size has been determined, false if unknown (-1).
+     * @return bool True if the file size has been determined, false if unknown.
      */
     public function hasKnownSize() : bool {
-        return $this->fileSize >= 0;
+        return $this->fileSize !== null;
     }
     /**
      * Checks if a given directory exists or not.
@@ -770,7 +770,7 @@ class File implements JsonI {
      *
      */
     public function toJSON() : Json {
-        $size = $this->getSize() != -1 ? $this->getSize() : 0;
+        $size = $this->getSize() ?? 0;
 
         return new Json([
             'id' => $this->getID(),
@@ -1051,8 +1051,8 @@ class File implements JsonI {
 
         return $retVal;
     }
-    private function setSize($size) {
-        if ($size >= 0) {
+    private function setSize(?int $size) {
+        if ($size !== null && $size >= 0) {
             $this->fileSize = $size;
         }
     }

--- a/WebFiori/File/FileUploader.php
+++ b/WebFiori/File/FileUploader.php
@@ -195,7 +195,7 @@ class FileUploader implements JsonI {
             $_FILES[$trimmed]['tmp_name'] = [];
             $_FILES[$trimmed]['error'] = [];
         }
-        $info = self::extractPathAndName($filePath);
+        $info = File::extractPathAndName($filePath);
         $path = $info['path'].DIRECTORY_SEPARATOR.$info['name'];
 
         if (!File::isFileExist($path)) {
@@ -513,40 +513,6 @@ class FileUploader implements JsonI {
         $file->setUploadErr($arr[UploaderConst::ERR_INDEX]);
 
         return $file;
-    }
-    /**
-     * Extracts directory path and filename from an absolute path.
-     * 
-     * This method splits an absolute file path into its directory component
-     * and filename component, normalizing directory separators in the process.
-     * 
-     * @param string $absPath The absolute path to extract from.
-     * 
-     * @return array An associative array with 'path' and 'name' keys.
-     */
-    private static function extractPathAndName($absPath): array {
-        $DS = DIRECTORY_SEPARATOR;
-        $cleanPath = str_replace('\\', $DS, str_replace('/', $DS, trim($absPath)));
-        $pathArr = explode($DS, $cleanPath);
-
-        if (count($pathArr) != 0) {
-            $fPath = '';
-            $name = $pathArr[count($pathArr) - 1];
-
-            for ($x = 0 ; $x < count($pathArr) - 1 ; $x++) {
-                $fPath .= $pathArr[$x].$DS;
-            }
-
-            return [
-                'path' => $fPath,
-                'name' => $name
-            ];
-        }
-
-        return [
-            'name' => $cleanPath,
-            'path' => ''
-        ];
     }
     /**
      * Processes file upload data and creates file information array.

--- a/WebFiori/File/FileUploader.php
+++ b/WebFiori/File/FileUploader.php
@@ -65,6 +65,12 @@ class FileUploader implements JsonI {
      */
     private $uploadDir;
     /**
+     * Custom maximum file size in bytes.
+     * 
+     * @var int|null
+     */
+    private $maxFileSize;
+    /**
      * Upload status message.
      * 
      * @var string
@@ -86,6 +92,7 @@ class FileUploader implements JsonI {
     public function __construct(string $uploadPath = '', array $allowedTypes = []) {
         $this->uploadStatusMessage = 'NO ACTION';
         $this->files = [];
+        $this->maxFileSize = null;
         $this->setAssociatedFileName('files');
         $this->addExts($allowedTypes);
         $this->uploadDir = '';
@@ -286,6 +293,24 @@ class FileUploader implements JsonI {
      */
     public function getUploadDir() : string {
         return $this->uploadDir;
+    }
+    /**
+     * Sets a custom maximum file size limit for this uploader instance.
+     * 
+     * @param int $bytes Maximum file size in bytes. Must be greater than 0.
+     */
+    public function setMaxFileSize(int $bytes) : void {
+        if ($bytes > 0) {
+            $this->maxFileSize = $bytes;
+        }
+    }
+    /**
+     * Returns the custom maximum file size limit.
+     * 
+     * @return int|null The limit in bytes, or null if no custom limit is set.
+     */
+    public function getMaxFileSizeLimit() : ?int {
+        return $this->maxFileSize;
     }
     /**
      * Removes an extension from the array of allowed files types.
@@ -543,7 +568,10 @@ class FileUploader implements JsonI {
 
         if (!$isErr) {
             if ($this->isValidExt($fileInfoArr[UploaderConst::NAME_INDEX])) {
-                if (File::isDirectory($this->getUploadDir())) {
+                if ($this->maxFileSize !== null && (int)$fileInfoArr[UploaderConst::SIZE_INDEX] > $this->maxFileSize) {
+                    $fileInfoArr[UploaderConst::UPLOADED_INDEX] = false;
+                    $fileInfoArr[UploaderConst::ERR_INDEX] = UploaderConst::ERR_FILE_TOO_LARGE;
+                } else if (File::isDirectory($this->getUploadDir())) {
                     $filePath = $this->getUploadDir().DIRECTORY_SEPARATOR.$fileInfoArr[UploaderConst::NAME_INDEX];
                     $moveFunc = http_response_code() === false ? 'copy' : 'move_uploaded_file';
 

--- a/WebFiori/File/UploaderConst.php
+++ b/WebFiori/File/UploaderConst.php
@@ -29,6 +29,10 @@ class UploaderConst {
      */
     const ERR_NOT_ALLOWED = 'not_allowed_type';
     /**
+     * A constant that is used to indicate uploaded file exceeds custom size limit.
+     */
+    const ERR_FILE_TOO_LARGE = 'file_too_large';
+    /**
      * One of the constants which is used to initialize uploaded file array.
      */
     const EXIST_INDEX = 'is-exist';

--- a/examples/file-information/README.md
+++ b/examples/file-information/README.md
@@ -18,7 +18,7 @@ Demonstrates how to retrieve file metadata and shows the two constructor forms.
 - `File::getName()` / `File::getNameWithNoExt()` / `File::getExtension()`
 - `File::getDir()` / `File::getAbsolutePath()`
 - `File::getMIME()` — Returns MIME type based on file extension.
-- `File::getSize()` — Returns size in bytes. Returns `-1` if file doesn't exist and no data is set.
+- `File::getSize()` — Returns size in bytes. Returns `null` if file doesn't exist and no data is set.
 - `File::getLastModified(?string $format)` — Pass a date format string, or `null` for a raw Unix timestamp. Returns `0` if the file doesn't exist.
 - `File::setId(string $id)` / `File::getID()` — Custom identifier for database-backed file storage.
 - `File::isExist()` — Checks if the file exists on disk.

--- a/tests/WebFiori/Framework/Test/File/FileTest.php
+++ b/tests/WebFiori/Framework/Test/File/FileTest.php
@@ -499,4 +499,98 @@ class FileTest extends TestCase {
                 'inline; filename="text-file-2.txt"'
         ], $response->getHeader('content-disposition'));
     }
+    /**
+     * @test
+     */
+    public function testReadWriteEmptyFile() {
+        $file = new File(ROOT_PATH.DS.'tests'.DS.'files'.DS.'empty-test.txt');
+        $file->create(true);
+        $this->assertTrue($file->isExist());
+        $this->assertEquals(0, $file->getSize());
+        $file->remove();
+    }
+    /**
+     * @test
+     */
+    public function testFileWithMultipleDots() {
+        $file = new File('archive.tar.gz', ROOT_PATH.DS.'tests'.DS.'files');
+        $this->assertEquals('archive.tar.gz', $file->getName());
+        $this->assertEquals('gz', $file->getExtension());
+        $this->assertEquals('archive.tar', $file->getNameWithNoExt());
+    }
+    /**
+     * @test
+     */
+    public function testFileWithNoExtension() {
+        $file = new File('Makefile', ROOT_PATH.DS.'tests'.DS.'files');
+        $this->assertEquals('Makefile', $file->getName());
+        $this->assertEquals('bin', $file->getExtension());
+        $this->assertEquals('Makefile', $file->getNameWithNoExt());
+    }
+    /**
+     * @test
+     */
+    public function testFixPathEdgeCases() {
+        $this->assertEquals('', File::fixPath(''));
+        $this->assertEquals('a', File::fixPath('a'));
+        $this->assertEquals('a'.DS.'b'.DS.'c', File::fixPath('a/b/c/'));
+        $this->assertEquals(DS.'root'.DS.'home', File::fixPath('/root/home/'));
+    }
+    /**
+     * @test
+     */
+    public function testSetRawDataEmptyString() {
+        $file = new File();
+        $file->setRawData('hello');
+        $this->assertEquals('hello', $file->getRawData());
+        // Empty string should not overwrite
+        $file->setRawData('');
+        $this->assertEquals('hello', $file->getRawData());
+    }
+    /**
+     * @test
+     */
+    public function testGetChunksLargerThanData() {
+        $file = new File();
+        $file->setRawData('short');
+        $chunks = $file->getChunks(1000, false);
+        $this->assertCount(1, $chunks);
+        $this->assertEquals('short', $chunks[0]);
+    }
+    /**
+     * @test
+     */
+    public function testGetChunksEqualToDataLength() {
+        $file = new File();
+        $file->setRawData('12345');
+        $chunks = $file->getChunks(5, false);
+        $this->assertCount(1, $chunks);
+        $this->assertEquals('12345', $chunks[0]);
+    }
+    /**
+     * @test
+     */
+    public function testGetLastModifiedFormat() {
+        $file = new File('text-file.txt', ROOT_PATH.DS.'tests'.DS.'files');
+        $ts = $file->getLastModified(null);
+        $this->assertIsInt($ts);
+        $this->assertGreaterThan(0, $ts);
+        $formatted = $file->getLastModified('Y');
+        $this->assertMatchesRegularExpression('/^\d{4}$/', $formatted);
+    }
+    /**
+     * @test
+     */
+    public function testGetLastModifiedNonExistent() {
+        $file = new File('does-not-exist.txt', ROOT_PATH.DS.'tests'.DS.'files');
+        $this->assertEquals(0, $file->getLastModified());
+    }
+    /**
+     * @test
+     */
+    public function testGetSizeUnsetFile() {
+        $file = new File();
+        $this->assertNull($file->getSize());
+        $this->assertFalse($file->hasKnownSize());
+    }
 }

--- a/tests/WebFiori/Framework/Test/File/MIMETest.php
+++ b/tests/WebFiori/Framework/Test/File/MIMETest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace WebFiori\Framework\Test\File;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\File\File;
+use WebFiori\File\MIME;
+
+class MIMETest extends TestCase {
+    /**
+     * @test
+     */
+    public function testCommonExtensions() {
+        $this->assertEquals('image/jpeg', MIME::getType('jpg'));
+        $this->assertEquals('image/png', MIME::getType('png'));
+        $this->assertEquals('text/plain', MIME::getType('txt'));
+        $this->assertEquals('text/html', MIME::getType('html'));
+        $this->assertEquals('audio/mpeg', MIME::getType('mp3'));
+        $this->assertEquals('video/mp4', MIME::getType('mp4'));
+        $this->assertEquals('application/zip', MIME::getType('zip'));
+        $this->assertEquals('application/pdf', MIME::getType('pdf'));
+    }
+    /**
+     * @test
+     */
+    public function testCaseInsensitive() {
+        $this->assertEquals('image/jpeg', MIME::getType('JPG'));
+        $this->assertEquals('image/png', MIME::getType('Png'));
+        $this->assertEquals('text/plain', MIME::getType('TXT'));
+        $this->assertEquals('text/html', MIME::getType('HTML'));
+    }
+    /**
+     * @test
+     */
+    public function testLeadingDot() {
+        $this->assertEquals('image/jpeg', MIME::getType('.jpg'));
+        $this->assertEquals('image/png', MIME::getType('.png'));
+        $this->assertEquals('application/pdf', MIME::getType('.pdf'));
+    }
+    /**
+     * @test
+     */
+    public function testUnknownExtension() {
+        $this->assertEquals(File::DEFAULT_MIME, MIME::getType('xyz123'));
+        $this->assertEquals(File::DEFAULT_MIME, MIME::getType('unknownext'));
+    }
+    /**
+     * @test
+     */
+    public function testEmptyString() {
+        $this->assertEquals(File::DEFAULT_MIME, MIME::getType(''));
+    }
+    /**
+     * @test
+     */
+    public function testWhitespace() {
+        // Spaces are not trimmed — treated as part of the extension
+        $this->assertEquals(File::DEFAULT_MIME, MIME::getType(' jpg '));
+        $this->assertEquals(File::DEFAULT_MIME, MIME::getType('   '));
+        // Tabs and newlines are trimmed
+        $this->assertEquals('image/png', MIME::getType("\tpng\n"));
+    }
+}

--- a/tests/WebFiori/Framework/Test/File/UploaderTest.php
+++ b/tests/WebFiori/Framework/Test/File/UploaderTest.php
@@ -227,4 +227,18 @@ class UploaderTest extends TestCase {
             'txt', 'jpg', 'png'
         ], $u->getExts());
     }
+    /**
+     * @test
+     */
+    public function testGetMaxFileSize() {
+        $val = ini_get('upload_max_filesize');
+        $lastChar = strtoupper($val[strlen($val) - 1]);
+        $expected = match ($lastChar) {
+            'M' => intval($val) * 1024,
+            'K' => intval($val),
+            'G' => intval($val) * 1048576,
+            default => intval($val) / 1024,
+        };
+        $this->assertEquals($expected, FileUploader::getMaxFileSize());
+    }
 }

--- a/tests/WebFiori/Framework/Test/File/UploaderTest.php
+++ b/tests/WebFiori/Framework/Test/File/UploaderTest.php
@@ -241,4 +241,50 @@ class UploaderTest extends TestCase {
         };
         $this->assertEquals($expected, FileUploader::getMaxFileSize());
     }
+    /**
+     * @test
+     */
+    public function testCustomMaxFileSize() {
+        $u = new FileUploader(__DIR__, ['txt']);
+        $this->assertNull($u->getMaxFileSizeLimit());
+        $u->setMaxFileSize(10);
+        $this->assertEquals(10, $u->getMaxFileSizeLimit());
+    }
+    /**
+     * @test
+     */
+    public function testCustomMaxFileSizeRejectsLargeFile() {
+        $_SERVER['REQUEST_METHOD'] = 'post';
+        $u = new FileUploader(__DIR__, ['txt']);
+        $u->setMaxFileSize(10); // 10 bytes limit
+        FileUploader::addTestFile('files', ROOT_PATH.'tests'.DS.'tmp'.DS.'testUpload.txt', true);
+        $r = $u->upload();
+        $this->assertFalse($r[0]['uploaded']);
+        $this->assertEquals('file_too_large', $r[0]['upload-error']);
+    }
+    /**
+     * @test
+     */
+    public function testCustomMaxFileSizeAllowsSmallFile() {
+        $_SERVER['REQUEST_METHOD'] = 'post';
+        $u = new FileUploader(__DIR__, ['txt']);
+        $u->setMaxFileSize(1024); // 1KB limit — file is 51 bytes
+        FileUploader::addTestFile('files', ROOT_PATH.'tests'.DS.'tmp'.DS.'testUpload.txt', true);
+        $r = $u->upload();
+        $this->assertTrue($r[0]['uploaded']);
+        $this->assertEquals('', $r[0]['upload-error']);
+        // cleanup
+        $files = $u->getFiles(true);
+        $files[0]->remove();
+    }
+    /**
+     * @test
+     */
+    public function testSetMaxFileSizeIgnoresInvalid() {
+        $u = new FileUploader(__DIR__, ['txt']);
+        $u->setMaxFileSize(0);
+        $this->assertNull($u->getMaxFileSizeLimit());
+        $u->setMaxFileSize(-100);
+        $this->assertNull($u->getMaxFileSizeLimit());
+    }
 }


### PR DESCRIPTION
## Summary

- **#42** — Deduplicate `extractPathAndName` into `File::extractPathAndName()` (public static)
- **#36** — Fix fragile byte-range logic in `readHelper` with explicit handling
- **#56** — Use `null` instead of `-1` for unset file size (**breaking**: `getSize()` returns `?int`)
- **#57, #58, #59** — Add tests for `MIME::getType()`, File edge cases, and `getMaxFileSize()`
- **#51** — Add custom per-uploader file size limit (`setMaxFileSize`/`getMaxFileSizeLimit`)

## Testing

All 85 tests pass (237 assertions).

## Breaking Changes

- `File::getSize()` return type changed from `int` to `?int`. Callers checking `=== -1` must use `=== null` or `hasKnownSize()`.