### PR TITLE
v2.1.0: FileInterface, streaming, decoupling, and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,12 @@ The [examples/](examples/) directory contains runnable PHP scripts covering ever
 | [JSON Serialization](examples/json-serialization/) | Convert `File` objects to JSON |
 | [Path Utilities](examples/path-utilities/) | Path normalization, directory creation, file existence checks |
 | [File Upload](examples/file-upload/) | Configure and process uploads with `FileUploader` |
-| [Serving Files](examples/serving-files/) | Serve files over HTTP with proper headers |
+| [Serving Files](examples/serving-files/) | Serve files over HTTP with ResponseEmitter |
+| [Streaming I/O](examples/streaming/) | Read chunks, lines, and ranges with `FileStream` |
+| [Copy and Move](examples/copy-and-move/) | Copy and move files with streaming |
+| [Atomic Write](examples/atomic-write/) | Crash-safe writes with temp + rename |
+| [Streaming Upload](examples/streaming-upload/) | Receive large files from `php://input` |
+| [Upload Callbacks](examples/upload-callbacks/) | Before/after hooks for validation and logging |
 
 Each example has its own README with detailed explanations. Run any example with:
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,42 @@ echo $file->getRawData();
 
 ## Core Classes
 
-- **`File`** — Read, write, create, remove, and serve files. Supports byte-range reads, Base64 encoding/decoding, chunked processing, and JSON serialization.
-- **`FileUploader`** — Handle file uploads with extension validation, size limits, and detailed error reporting.
+- **`FileInterface`** — Contract defining core file operations. Use for type-hinting and mocking.
+- **`File`** — Read, write, create, remove, copy, move, and serve files. Supports byte-range reads, Base64 encoding/decoding, chunked processing, and JSON serialization.
+- **`FileStream`** — Streaming file I/O with constant memory usage. Read chunks, lines, ranges, and serve large files.
+- **`FileUploader`** — Handle file uploads with extension validation, size limits, stream processing, and callback hooks.
 - **`UploadedFile`** — Extends `File` with upload-specific properties (upload status, replacement status, error message).
+- **`ResponseEmitter`** — Interface for abstracting HTTP output when serving files.
 - **`MIME`** — Static lookup of ~600 file extension to MIME type mappings.
+
+## Using FileInterface
+
+Type-hint `FileInterface` when your code only needs I/O operations. Use the concrete `File` class when you need encoding, serialization, or HTTP features.
+
+```php
+use WebFiori\File\FileInterface;
+
+class DocumentService {
+    public function process(FileInterface $file): string {
+        $file->read();
+        return strtoupper($file->getRawData());
+    }
+}
+```
+
+### Mocking in Tests
+
+```php
+use WebFiori\File\FileInterface;
+
+$mockFile = $this->createMock(FileInterface::class);
+$mockFile->method('getRawData')->willReturn('test content');
+$mockFile->method('getName')->willReturn('test.txt');
+$mockFile->method('isExist')->willReturn(true);
+
+$service = new DocumentService();
+$result = $service->process($mockFile);
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebFiori File
 
-A PHP library for file operations, providing an object-oriented abstraction layer for reading, writing, uploading, and serving files with Base64 encoding/decoding, MIME type detection, and chunked file processing.
+A PHP library for file operations, providing an object-oriented abstraction layer for reading, writing, uploading, and serving files with streaming support, Base64 encoding/decoding, MIME type detection, and chunked file processing.
 
 <p align="center">
   <a target="_blank" href="https://github.com/WebFiori/file/actions/workflows/php84.yaml">
@@ -12,21 +12,28 @@ A PHP library for file operations, providing an object-oriented abstraction laye
   <a href="https://sonarcloud.io/dashboard?id=WebFiori_file">
       <img src="https://sonarcloud.io/api/project_badges/measure?project=WebFiori_file&metric=alert_status" />
   </a>
+  <a href="https://github.com/WebFiori/file/releases">
+    <img src="https://img.shields.io/github/v/release/WebFiori/file">
+  </a>
   <a href="https://packagist.org/packages/webfiori/file">
     <img src="https://img.shields.io/packagist/dt/webfiori/file?color=light-green">
   </a>
 </p>
 
-## Installation
+## Table of Contents
 
-```bash
-composer require webfiori/file
-```
-
-## Requirements
-
-- PHP 8.1 or higher
-- `webfiori/jsonx` ^4.0
+- [Supported PHP Versions](#supported-php-versions)
+- [Key Features](#key-features)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Core Classes](#core-classes)
+- [Using FileInterface](#using-fileinterface)
+- [Examples](#examples)
+- [Testing](#testing)
+- [Contributing](#contributing)
+- [License](#license)
+- [Support](#support)
+- [Changelog](#changelog)
 
 ## Supported PHP Versions
 
@@ -36,6 +43,29 @@ composer require webfiori/file
 | <a target="_blank" href="https://github.com/WebFiori/file/actions/workflows/php82.yaml"><img src="https://github.com/WebFiori/file/actions/workflows/php82.yaml/badge.svg?branch=main"></a> |
 | <a target="_blank" href="https://github.com/WebFiori/file/actions/workflows/php83.yaml"><img src="https://github.com/WebFiori/file/actions/workflows/php83.yaml/badge.svg?branch=main"></a> |
 | <a target="_blank" href="https://github.com/WebFiori/file/actions/workflows/php84.yaml"><img src="https://github.com/WebFiori/file/actions/workflows/php84.yaml/badge.svg?branch=main"></a> |
+
+## Key Features
+
+- Object-oriented file read, write, create, remove, copy, and move
+- Streaming I/O with constant memory usage via `FileStream`
+- File upload handling with extension validation, size limits, and callback hooks
+- Stream processing during uploads with hash verification support
+- Atomic writes (temp + rename) for crash-safe operations
+- Base64 encoding/decoding
+- Byte-range reads for partial file access
+- MIME type detection for ~600 file extensions
+- `ResponseEmitter` interface for framework-agnostic HTTP file serving
+- `FileInterface` for dependency injection and mocking
+
+## Installation
+
+```bash
+composer require webfiori/file
+```
+
+**Requirements:**
+- PHP 8.1 or higher
+- `webfiori/jsonx` ^4.0
 
 ## Quick Start
 
@@ -135,3 +165,11 @@ composer test10
 ## License
 
 MIT — see [LICENSE](LICENSE) for details.
+
+## Support
+
+Found a bug or have a feature request? [Open an issue](https://github.com/WebFiori/file/issues).
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.

--- a/WebFiori/File/AbstractUploader.php
+++ b/WebFiori/File/AbstractUploader.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\File;
+
+use WebFiori\File\Exceptions\FileException;
+
+/**
+ * Base class for file uploaders providing shared validation, extension filtering,
+ * size limits, stream processing, and callback hooks.
+ *
+ * @author Ibrahim
+ */
+abstract class AbstractUploader {
+    /**
+     * @var array
+     */
+    private $extensions = [];
+    /**
+     * @var string
+     */
+    private $uploadDir;
+    /**
+     * @var int|null
+     */
+    private $maxFileSize;
+    /**
+     * @var callable|null
+     */
+    private $streamProcessor;
+    /**
+     * @var callable|null
+     */
+    private $onBeforeUpload;
+    /**
+     * @var callable|null
+     */
+    private $onAfterUpload;
+
+    public function __construct(string $uploadPath = '', array $allowedTypes = []) {
+        $this->maxFileSize = null;
+        $this->streamProcessor = null;
+        $this->onBeforeUpload = null;
+        $this->onAfterUpload = null;
+        $this->uploadDir = '';
+        $this->addExts($allowedTypes);
+
+        if (strlen($uploadPath) != 0) {
+            $this->setUploadDir($uploadPath);
+        }
+    }
+
+    /**
+     * Adds new extension to the array of allowed files types.
+     *
+     * @param string $ext File extension (e.g. jpg, png, pdf).
+     *
+     * @return bool If the extension is added, the method will return true.
+     */
+    public function addExt(string $ext): bool {
+        $ext = str_replace('.', '', $ext);
+        $len = strlen($ext);
+        $retVal = true;
+
+        if ($len != 0) {
+            for ($x = 0; $x < $len; $x++) {
+                $ch = $ext[$x];
+
+                if (!($ch == '_' || ($ch >= 'a' && $ch <= 'z') || ($ch >= 'A' && $ch <= 'Z') || ($ch >= '0' && $ch <= '9'))) {
+                    $retVal = false;
+                    break;
+                }
+            }
+
+            if ($retVal === true) {
+                $this->extensions[] = $ext;
+            }
+        } else {
+            $retVal = false;
+        }
+
+        return $retVal;
+    }
+
+    /**
+     * Adds multiple extensions at once to the set of allowed files types.
+     *
+     * @param array $arr An array of strings. Each string represents a file type.
+     *
+     * @return array Associative array of extension => bool.
+     */
+    public function addExts(array $arr): array {
+        $retVal = [];
+
+        foreach ($arr as $ext) {
+            $retVal[$ext] = $this->addExt($ext);
+        }
+
+        return $retVal;
+    }
+
+    /**
+     * Returns the array that contains all allowed file types.
+     *
+     * @return array
+     */
+    public function getExts(): array {
+        return $this->extensions;
+    }
+
+    /**
+     * Removes an extension from the array of allowed files types.
+     *
+     * @param string $ext File extension (e.g. jpg, png, pdf).
+     *
+     * @return bool If the extension was removed, the method will return true.
+     */
+    public function removeExt(string $ext): bool {
+        $exts = $this->getExts();
+        $count = count($exts);
+        $retVal = false;
+        $temp = [];
+        $ext = str_replace('.', '', $ext);
+
+        for ($x = 0; $x < $count; $x++) {
+            if ($exts[$x] != $ext) {
+                $temp[] = $exts[$x];
+            } else {
+                $retVal = true;
+            }
+        }
+        $this->extensions = $temp;
+
+        return $retVal;
+    }
+
+    /**
+     * Returns the directory at which the file or files will be uploaded to.
+     *
+     * @return string upload directory.
+     */
+    public function getUploadDir(): string {
+        return $this->uploadDir;
+    }
+
+    /**
+     * Sets the directory at which the file will be uploaded to.
+     *
+     * @param string $dir Upload Directory.
+     *
+     * @throws FileException If given directory is invalid.
+     */
+    public function setUploadDir(string $dir): void {
+        $fixedPath = File::fixPath($dir);
+
+        if (strlen($fixedPath) == 0) {
+            throw new FileException('Upload directory should not be an empty string.');
+        }
+
+        try {
+            if (!File::isDirectory($fixedPath)) {
+                throw new FileException('Invalid upload directory: ' . $fixedPath);
+            }
+
+            $this->uploadDir = $fixedPath;
+        } catch (FileException $ex) {
+            throw new FileException('Invalid upload directory: ' . $fixedPath);
+        }
+    }
+
+    /**
+     * Sets a custom maximum file size limit.
+     *
+     * @param int $bytes Maximum file size in bytes.
+     */
+    public function setMaxFileSize(int $bytes): void {
+        if ($bytes > 0) {
+            $this->maxFileSize = $bytes;
+        }
+    }
+
+    /**
+     * Returns the custom maximum file size limit.
+     *
+     * @return int|null The limit in bytes, or null if not set.
+     */
+    public function getMaxFileSizeLimit(): ?int {
+        return $this->maxFileSize;
+    }
+
+    /**
+     * Sets a stream processor for upload processing.
+     *
+     * @param callable|null $processor Signature: function(\Generator $chunks, string $destPath): void
+     */
+    public function setStreamProcessor(?callable $processor): void {
+        $this->streamProcessor = $processor;
+    }
+
+    /**
+     * Returns the current stream processor.
+     *
+     * @return callable|null
+     */
+    public function getStreamProcessor(): ?callable {
+        return $this->streamProcessor;
+    }
+
+    /**
+     * Sets a callback to be called before each file is uploaded.
+     *
+     * @param callable|null $callback Signature: function(array $fileInfo): bool
+     */
+    public function setOnBeforeUpload(?callable $callback): void {
+        $this->onBeforeUpload = $callback;
+    }
+
+    /**
+     * Returns the before-upload callback.
+     *
+     * @return callable|null
+     */
+    public function getOnBeforeUpload(): ?callable {
+        return $this->onBeforeUpload;
+    }
+
+    /**
+     * Sets a callback to be called after each successful file upload.
+     *
+     * @param callable|null $callback Signature: function(UploadedFile $file): void
+     */
+    public function setOnAfterUpload(?callable $callback): void {
+        $this->onAfterUpload = $callback;
+    }
+
+    /**
+     * Returns the after-upload callback.
+     *
+     * @return callable|null
+     */
+    public function getOnAfterUpload(): ?callable {
+        return $this->onAfterUpload;
+    }
+
+    /**
+     * Sanitizes an uploaded filename.
+     *
+     * @param string $name The raw filename.
+     *
+     * @return string The sanitized filename.
+     */
+    public static function sanitizeFilename(string $name): string {
+        $name = str_replace("\\", "/", $name);
+        $name = basename($name);
+        $name = str_replace("\0", '', $name);
+        $name = preg_replace('/[^\w\-. ]/', '_', $name);
+        $name = ltrim($name, '.');
+
+        return $name;
+    }
+
+    /**
+     * Checks if a filename has an allowed extension.
+     *
+     * @param string $fileName The filename to check.
+     *
+     * @return bool True if allowed.
+     */
+    protected function isValidExt(string $fileName): bool {
+        $ext = pathinfo($fileName, PATHINFO_EXTENSION);
+
+        return in_array($ext, $this->getExts(), true) || in_array(strtolower($ext), $this->getExts(), true);
+    }
+
+    /**
+     * Invokes the before-upload callback.
+     *
+     * @param array $fileInfo File information array.
+     *
+     * @return bool True if upload should proceed.
+     */
+    protected function fireBeforeUpload(array $fileInfo): bool {
+        if ($this->onBeforeUpload !== null) {
+            return ($this->onBeforeUpload)($fileInfo) !== false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Invokes the after-upload callback.
+     *
+     * @param UploadedFile $file The uploaded file.
+     */
+    protected function fireAfterUpload(UploadedFile $file): void {
+        if ($this->onAfterUpload !== null) {
+            ($this->onAfterUpload)($file);
+        }
+    }
+}

--- a/WebFiori/File/DefaultEmitter.php
+++ b/WebFiori/File/DefaultEmitter.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\File;
+
+/**
+ * A default ResponseEmitter that uses raw PHP header() and echo for output.
+ *
+ * @author Ibrahim
+ */
+class DefaultEmitter implements ResponseEmitter {
+    public function setHeader(string $name, string $value): void {
+        header("$name: $value");
+    }
+
+    public function setStatusCode(int $code): void {
+        http_response_code($code);
+    }
+
+    public function sendBody(\Generator $chunks): void {
+        foreach ($chunks as $chunk) {
+            if (connection_aborted()) {
+                break;
+            }
+            echo $chunk;
+            flush();
+        }
+    }
+}

--- a/WebFiori/File/File.php
+++ b/WebFiori/File/File.php
@@ -807,7 +807,7 @@ class File implements FileInterface, JsonI {
      * If MIME type of the file is not set.
      *
      */
-    public function view(bool $asAttachment = false, bool $terminate = true) : void {
+    public function view(bool $asAttachment = false, bool $terminate = false) : void {
         $raw = $this->getRawData();
 
         if (strlen($raw) == 0) {

--- a/WebFiori/File/File.php
+++ b/WebFiori/File/File.php
@@ -2,8 +2,6 @@
 namespace WebFiori\File;
 
 use WebFiori\File\Exceptions\FileException;
-use WebFiori\Framework\App;
-use WebFiori\Http\Response;
 use WebFiori\Json\Json;
 use WebFiori\Json\JsonI;
 /**
@@ -64,11 +62,11 @@ class File implements FileInterface, JsonI {
      */
     private $rawData;
     /**
-     * The response object used when serving the file.
+     * The response emitter used when serving the file.
      * 
-     * @var Response|null
+     * @var ResponseEmitter|null
      */
-    private $response;
+    private $emitter;
     /**
      * Creates new instance of the class.
      * 
@@ -457,15 +455,20 @@ class File implements FileInterface, JsonI {
         return base64_encode($this->rawData);
     }
     /**
-     * Returns the response object that was used to serve the file.
+     * Returns the response emitter used when serving the file.
      *
-     * This method is useful for testing. It returns the response
-     * object that was created when view() was called.
-     *
-     * @return Response|null The response object, or null if view() was not called.
+     * @return ResponseEmitter|null The emitter, or null if not set.
      */
-    public function getResponse() {
-        return $this->response;
+    public function getResponseEmitter(): ?ResponseEmitter {
+        return $this->emitter;
+    }
+    /**
+     * Sets the response emitter to use when serving the file.
+     *
+     * @param ResponseEmitter|null $emitter The emitter to use. Pass null to reset to default.
+     */
+    public function setResponseEmitter(?ResponseEmitter $emitter): void {
+        $this->emitter = $emitter;
     }
     /**
      * Returns the size of the file in bytes.
@@ -813,7 +816,7 @@ class File implements FileInterface, JsonI {
         if (strlen($raw) == 0) {
             $this->read();
         }
-        $this->viewFileHelper($asAttachment, $terminate);
+        $this->viewFileHelper($asAttachment);
     }
     /**
      * Write raw binary data into a file.
@@ -893,40 +896,6 @@ class File implements FileInterface, JsonI {
             throw new FileException('Path cannot be empty string.');
         }
         throw new FileException('File name cannot be empty string.');
-    }
-    private function doNotUseClassResponse($contentType, $asAttachment, bool $terminate = true) {
-        $headersArr = [
-            'Accept-Ranges: bytes',
-            'content-type: '.$contentType
-        ];
-
-        if (isset($_SERVER['HTTP_RANGE'])) {
-            $expl = $this->readRange();
-            http_response_code(206);
-            $headersArr[] = 'content-range: '.'bytes '.$expl[0].'-'.$expl[1].'/'.$this->getSize();
-            $headersArr[] = 'content-length: '.($expl[1] - $expl[0]);
-        } else {
-            $headersArr[] = 'Content-Length: '.$this->getSize();
-        }
-
-        if ($asAttachment === true) {
-            $headersArr[] = 'Content-Disposition: attachment; filename="'.$this->getName().'"';
-        } else {
-            $headersArr[] = 'Content-Disposition: inline; filename="'.$this->getName().'"';
-        }
-
-        foreach ($headersArr as $h) {
-            //Check if in PHP Unit or not. If in 
-            if (!defined('TESTING') || TESTING === false) {
-                header($h);
-            }
-        }
-        echo $this->getRawData();
-
-        if (http_response_code() === false) {
-            return;
-        }
-        if ($terminate) { die(); }
     }
     private function extractMimeFromName() {
         $exp = explode('.', $this->getName());
@@ -1067,44 +1036,27 @@ class File implements FileInterface, JsonI {
         }
     }
 
-    private function useClassResponse($contentType, $asAttachment) {
-        if (class_exists('\Webfiori\Framework\App')) {
-            $response = App::getResponse();
-        } else {
-            $response = new Response();
-        }
-        $response->addHeader('Accept-Ranges', 'bytes');
-        $response->addHeader('content-type', $contentType);
+    private function viewFileHelper($asAttachment) {
+        $emitter = $this->emitter ?? new DefaultEmitter();
+        $contentType = $this->getMIME();
+
+        $emitter->setHeader('Accept-Ranges', 'bytes');
+        $emitter->setHeader('Content-Type', $contentType);
 
         if (isset($_SERVER['HTTP_RANGE'])) {
             $expl = $this->readRange();
-            $response->setCode(206);
-            $response->addHeader('content-range', 'bytes '.$expl[0].'-'.$expl[1].'/'.$this->getSize());
-            $response->addHeader('content-length', $expl[1] - $expl[0]);
+            $emitter->setStatusCode(206);
+            $emitter->setHeader('Content-Range', 'bytes '.$expl[0].'-'.$expl[1].'/'.$this->getSize());
+            $emitter->setHeader('Content-Length', (string)($expl[1] - $expl[0]));
         } else {
-            $response->addHeader('Content-Length', $this->getSize());
+            $emitter->setHeader('Content-Length', (string)$this->getSize());
         }
 
-        if ($asAttachment === true) {
-            $response->addHeader('Content-Disposition', 'attachment; filename="'.$this->getName().'"');
-        } else {
-            $response->addHeader('Content-Disposition', 'inline; filename="'.$this->getName().'"');
-        }
-        $response->write($this->getRawData());
-        $this->response = $response;
+        $disposition = $asAttachment ? 'attachment' : 'inline';
+        $emitter->setHeader('Content-Disposition', $disposition.'; filename="'.$this->getName().'"');
 
-        if (!defined('__PHPUNIT_PHAR__')) {
-            $response->send();
-        }
-    }
-    private function viewFileHelper($asAttachment, bool $terminate = true) {
-        $contentType = $this->getMIME();
-
-        if (class_exists('\WebFiori\Http\Response')) {
-            $this->useClassResponse($contentType, $asAttachment);
-        } else {
-            $this->doNotUseClassResponse($contentType, $asAttachment, $terminate);
-        }
+        $data = $this->getRawData();
+        $emitter->sendBody((function () use ($data) { yield $data; })());
     }
 
     /**

--- a/WebFiori/File/File.php
+++ b/WebFiori/File/File.php
@@ -15,7 +15,7 @@ use WebFiori\Json\JsonI;
  * @author Ibrahim
  * 
  */
-class File implements JsonI {
+class File implements FileInterface, JsonI {
     /**
      * The default MIME type of all files.
      * 

--- a/WebFiori/File/File.php
+++ b/WebFiori/File/File.php
@@ -616,7 +616,7 @@ class File implements FileInterface, JsonI {
         return false;
     }
     /**
-     * Copies the file to a new destination.
+     * Copies the file to a new destination using streaming for constant memory usage.
      *
      * @param string $destination The destination path including filename.
      *
@@ -633,14 +633,20 @@ class File implements FileInterface, JsonI {
 
         self::isDirectory($info['path'], true);
 
-        if (!@copy($this->getAbsolutePath(), $dest)) {
-            throw new FileException('Unable to copy file to \''.$dest.'\'.');
-        }
+        $destFile = new File($dest);
+        $destFile->create(true);
+
+        $source = new FileStream($this->getAbsolutePath());
+        $target = new FileStream($destFile->getAbsolutePath());
+        $target->writeFromStream($source->readChunks(), false);
 
         return new File($dest);
     }
     /**
      * Moves the file to a new destination, updating this instance's path and name.
+     *
+     * Tries rename() first (instant on same device), falls back to
+     * streaming copy + remove for cross-device moves.
      *
      * @param string $destination The destination path including filename.
      *
@@ -655,10 +661,17 @@ class File implements FileInterface, JsonI {
 
         self::isDirectory($info['path'], true);
 
-        if (!@rename($this->getAbsolutePath(), $dest)) {
-            throw new FileException('Unable to move file to \''.$dest.'\'.');
+        if (@rename($this->getAbsolutePath(), $dest)) {
+            $this->setDir($info['path']);
+            $this->setName($info['name']);
+
+            return;
         }
 
+        // Cross-device fallback: stream copy + remove
+        $this->copy($dest);
+        $this->rawData = '';
+        unlink($this->getAbsolutePath());
         $this->setDir($info['path']);
         $this->setName($info['name']);
     }

--- a/WebFiori/File/File.php
+++ b/WebFiori/File/File.php
@@ -783,6 +783,16 @@ class File implements FileInterface, JsonI {
         ]);
     }
     /**
+     * Returns a FileStream instance for streaming operations on this file.
+     *
+     * @param int $bufferSize The buffer size for streaming operations.
+     *
+     * @return FileStream
+     */
+    public function stream(int $bufferSize = 8192): FileStream {
+        return new FileStream($this->getAbsolutePath(), $bufferSize);
+    }
+    /**
      * Display the file.
      *
      * If the raw data of the file is null, the method will

--- a/WebFiori/File/File.php
+++ b/WebFiori/File/File.php
@@ -616,6 +616,53 @@ class File implements FileInterface, JsonI {
         return false;
     }
     /**
+     * Copies the file to a new destination.
+     *
+     * @param string $destination The destination path including filename.
+     *
+     * @return FileInterface A new instance representing the copy.
+     *
+     * @throws FileException If the file does not exist or copy fails.
+     */
+    public function copy(string $destination): FileInterface {
+        if (!$this->isExist()) {
+            throw new FileException('File not found: \''.$this->getAbsolutePath().'\'.');
+        }
+        $dest = self::fixPath($destination);
+        $info = self::extractPathAndName($dest);
+
+        self::isDirectory($info['path'], true);
+
+        if (!@copy($this->getAbsolutePath(), $dest)) {
+            throw new FileException('Unable to copy file to \''.$dest.'\'.');
+        }
+
+        return new File($dest);
+    }
+    /**
+     * Moves the file to a new destination, updating this instance's path and name.
+     *
+     * @param string $destination The destination path including filename.
+     *
+     * @throws FileException If the file does not exist or move fails.
+     */
+    public function moveTo(string $destination): void {
+        if (!$this->isExist()) {
+            throw new FileException('File not found: \''.$this->getAbsolutePath().'\'.');
+        }
+        $dest = self::fixPath($destination);
+        $info = self::extractPathAndName($dest);
+
+        self::isDirectory($info['path'], true);
+
+        if (!@rename($this->getAbsolutePath(), $dest)) {
+            throw new FileException('Unable to move file to \''.$dest.'\'.');
+        }
+
+        $this->setDir($info['path']);
+        $this->setName($info['name']);
+    }
+    /**
      * Sets the name of the directory at which the file exist on.
      *
      * The directory is simply the folder that contains the file. For example,

--- a/WebFiori/File/FileInterface.php
+++ b/WebFiori/File/FileInterface.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\File;
+
+/**
+ * An interface that defines core file operations.
+ *
+ * This interface captures the essential behavior of a file object,
+ * enabling dependency injection, mocking, and alternative implementations.
+ *
+ * @author Ibrahim
+ */
+interface FileInterface {
+    /**
+     * Returns the name of the file.
+     *
+     * @return string The name of the file including extension.
+     */
+    public function getName(): string;
+
+    /**
+     * Sets the name of the file.
+     *
+     * @param string $name The name of the file including extension.
+     */
+    public function setName(string $name): void;
+
+    /**
+     * Returns the directory at which the file exists.
+     *
+     * @return string The directory path.
+     */
+    public function getDir(): string;
+
+    /**
+     * Sets the directory at which the file exists.
+     *
+     * @param string $dir The directory path.
+     *
+     * @return bool True if set successfully, false otherwise.
+     */
+    public function setDir(string $dir): bool;
+
+    /**
+     * Returns the full absolute path to the file.
+     *
+     * @return string Full path including directory and name.
+     */
+    public function getAbsolutePath(): string;
+
+    /**
+     * Returns the file extension.
+     *
+     * @return string The file extension (e.g. 'txt', 'png').
+     */
+    public function getExtension(): string;
+
+    /**
+     * Returns the MIME type of the file.
+     *
+     * @return string MIME type string.
+     */
+    public function getMIME(): string;
+
+    /**
+     * Returns the size of the file in bytes.
+     *
+     * @return int|null Size in bytes, or null if unknown.
+     */
+    public function getSize(): ?int;
+
+    /**
+     * Checks if the file exists on the filesystem.
+     *
+     * @return bool True if the file exists.
+     */
+    public function isExist(): bool;
+
+    /**
+     * Returns the raw data of the file.
+     *
+     * @param bool $encode If true, returns base64-encoded data.
+     *
+     * @return string The raw file data.
+     */
+    public function getRawData(bool $encode = false): string;
+
+    /**
+     * Sets the raw data of the file.
+     *
+     * @param string $raw The raw data.
+     * @param bool $decode If true, decodes from base64 before storing.
+     * @param bool $strict If true, strict base64 decoding is used.
+     */
+    public function setRawData(string $raw, bool $decode = false, bool $strict = false): void;
+
+    /**
+     * Appends data to the file's in-memory content.
+     *
+     * @param string|array $data Data to append.
+     */
+    public function append(string|array $data): void;
+
+    /**
+     * Reads the file content from the filesystem.
+     *
+     * @param int $from Starting byte offset (-1 for beginning).
+     * @param int $to Ending byte offset (-1 for end of file).
+     */
+    public function read(int $from = -1, int $to = -1): void;
+
+    /**
+     * Writes the file content to the filesystem.
+     *
+     * @param bool $append If true, appends to existing content.
+     * @param bool $createIfNotExist If true, creates the file if it doesn't exist.
+     */
+    public function write(bool $append = true, bool $createIfNotExist = false): void;
+
+    /**
+     * Creates the file on the filesystem if it does not exist.
+     *
+     * @param bool $createDirIfNotExist If true, creates parent directories as needed.
+     */
+    public function create(bool $createDirIfNotExist = false): void;
+
+    /**
+     * Removes the file from the filesystem.
+     *
+     * @return bool True if successfully removed.
+     */
+    public function remove(): bool;
+}

--- a/WebFiori/File/FileInterface.php
+++ b/WebFiori/File/FileInterface.php
@@ -138,4 +138,20 @@ interface FileInterface {
      * @return bool True if successfully removed.
      */
     public function remove(): bool;
+
+    /**
+     * Copies the file to a new destination.
+     *
+     * @param string $destination The destination path including filename.
+     *
+     * @return FileInterface A new instance representing the copy.
+     */
+    public function copy(string $destination): FileInterface;
+
+    /**
+     * Moves the file to a new destination.
+     *
+     * @param string $destination The destination path including filename.
+     */
+    public function moveTo(string $destination): void;
 }

--- a/WebFiori/File/FileStream.php
+++ b/WebFiori/File/FileStream.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\File;
+
+use WebFiori\File\Exceptions\FileException;
+
+/**
+ * A streaming file class that processes files in constant memory.
+ *
+ * Unlike the File class which loads entire content into memory,
+ * FileStream uses generators to read and write data in fixed-size
+ * buffers, making it suitable for large files.
+ *
+ * @author Ibrahim
+ */
+class FileStream implements StreamableInterface {
+    private string $path;
+    private int $bufferSize;
+
+    /**
+     * Creates a new FileStream instance.
+     *
+     * @param string $path Absolute path to the file.
+     * @param int $bufferSize Default buffer size for read operations.
+     *
+     * @throws FileException If path is empty.
+     */
+    public function __construct(string $path, int $bufferSize = 8192) {
+        $path = File::fixPath($path);
+
+        if (strlen($path) === 0) {
+            throw new FileException('File path cannot be empty.');
+        }
+        $this->path = $path;
+        $this->setBufferSize($bufferSize);
+    }
+
+    public function readChunks(int $bufferSize = 8192): \Generator {
+        $bufferSize = $bufferSize > 0 ? $bufferSize : $this->bufferSize;
+        $resource = $this->openOrFail('rb');
+
+        try {
+            while (!feof($resource)) {
+                $chunk = fread($resource, $bufferSize);
+
+                if ($chunk === false || strlen($chunk) === 0) {
+                    break;
+                }
+                yield $chunk;
+            }
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function readLines(): \Generator {
+        $resource = $this->openOrFail('rb');
+
+        try {
+            while (($line = fgets($resource)) !== false) {
+                yield $line;
+            }
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function readRange(int $from, int $to, int $bufferSize = 8192): \Generator {
+        if ($from < 0 || $to < $from) {
+            throw new FileException('Invalid range: from must be >= 0 and to must be >= from.');
+        }
+        $bufferSize = $bufferSize > 0 ? $bufferSize : $this->bufferSize;
+        $resource = $this->openOrFail('rb');
+
+        try {
+            fseek($resource, $from);
+            $remaining = $to - $from;
+
+            while ($remaining > 0 && !feof($resource)) {
+                $readSize = min($bufferSize, $remaining);
+                $chunk = fread($resource, $readSize);
+
+                if ($chunk === false || strlen($chunk) === 0) {
+                    break;
+                }
+                $remaining -= strlen($chunk);
+                yield $chunk;
+            }
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function writeFromStream(iterable $source, bool $append = true, bool $lock = true): void {
+        $mode = $append ? 'ab' : 'wb';
+        $resource = $this->openOrFail($mode);
+
+        try {
+            if ($lock && !flock($resource, LOCK_EX)) {
+                throw new FileException('Unable to acquire lock on \'' . $this->path . '\'.');
+            }
+
+            foreach ($source as $chunk) {
+                fwrite($resource, $chunk);
+            }
+            fflush($resource);
+
+            if ($lock) {
+                flock($resource, LOCK_UN);
+            }
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function serve(bool $asAttachment = false, ?ResponseEmitter $emitter = null): void {
+        if (!File::isFileExist($this->path)) {
+            throw new FileException('File not found: \'' . $this->path . '\'.');
+        }
+
+        $emitter = $emitter ?? new DefaultEmitter();
+        $emitter->setStatusCode(200);
+        $emitter->setHeader('Accept-Ranges', 'bytes');
+        $emitter->setHeader('Content-Type', $this->getMIME());
+        $emitter->setHeader('Content-Length', (string) $this->getSize());
+
+        $disposition = $asAttachment ? 'attachment' : 'inline';
+        $emitter->setHeader('Content-Disposition', $disposition . '; filename="' . $this->getName() . '"');
+
+        $emitter->sendBody($this->readChunks($this->bufferSize));
+    }
+
+    public function getSize(): int {
+        if (!File::isFileExist($this->path)) {
+            return 0;
+        }
+
+        return filesize($this->path);
+    }
+
+    public function getMIME(): string {
+        $ext = pathinfo($this->path, PATHINFO_EXTENSION);
+
+        return MIME::getType($ext);
+    }
+
+    public function getName(): string {
+        return basename($this->path);
+    }
+
+    /**
+     * Returns the default buffer size.
+     *
+     * @return int Buffer size in bytes.
+     */
+    public function getBufferSize(): int {
+        return $this->bufferSize;
+    }
+
+    /**
+     * Sets the default buffer size.
+     *
+     * @param int $size Buffer size in bytes. Must be greater than 0.
+     */
+    public function setBufferSize(int $size): void {
+        $this->bufferSize = $size > 0 ? $size : 8192;
+    }
+
+    /**
+     * Returns the absolute path to the file.
+     *
+     * @return string
+     */
+    public function getPath(): string {
+        return $this->path;
+    }
+
+    /**
+     * Opens the file or throws an exception.
+     *
+     * @param string $mode fopen mode.
+     *
+     * @return resource
+     *
+     * @throws FileException
+     */
+    private function openOrFail(string $mode) {
+        $resource = File::createResource($mode, $this->path);
+
+        if (!is_resource($resource)) {
+            throw new FileException('Unable to open file: \'' . $this->path . '\'.');
+        }
+
+        return $resource;
+    }
+}

--- a/WebFiori/File/FileStream.php
+++ b/WebFiori/File/FileStream.php
@@ -121,6 +121,45 @@ class FileStream implements StreamableInterface {
         }
     }
 
+    /**
+     * Writes data atomically using a temp file and rename.
+     *
+     * Data is written to a temporary file first, then renamed to the target
+     * path. This ensures the target file is never left in a partial state.
+     *
+     * @param iterable $source An iterable yielding string chunks.
+     *
+     * @throws FileException If write or rename fails.
+     */
+    public function writeAtomic(iterable $source): void {
+        $tempPath = $this->path . '.tmp.' . getmypid();
+        $handle = @fopen($tempPath, 'wb');
+
+        if (!is_resource($handle)) {
+            throw new FileException('Unable to create temp file: \'' . $tempPath . '\'.');
+        }
+
+        try {
+            foreach ($source as $chunk) {
+                fwrite($handle, $chunk);
+            }
+            fflush($handle);
+            fclose($handle);
+            $handle = null;
+
+            if (!@rename($tempPath, $this->path)) {
+                throw new FileException('Atomic rename failed for \'' . $this->path . '\'.');
+            }
+        } finally {
+            if (is_resource($handle)) {
+                fclose($handle);
+            }
+            if (file_exists($tempPath)) {
+                unlink($tempPath);
+            }
+        }
+    }
+
     public function serve(bool $asAttachment = false, ?ResponseEmitter $emitter = null): void {
         if (!File::isFileExist($this->path)) {
             throw new FileException('File not found: \'' . $this->path . '\'.');

--- a/WebFiori/File/FileUploader.php
+++ b/WebFiori/File/FileUploader.php
@@ -77,6 +77,18 @@ class FileUploader implements JsonI {
      */
     private $streamProcessor;
     /**
+     * Callback called before each file upload.
+     * 
+     * @var callable|null
+     */
+    private $onBeforeUpload;
+    /**
+     * Callback called after each successful file upload.
+     * 
+     * @var callable|null
+     */
+    private $onAfterUpload;
+    /**
      * Upload status message.
      * 
      * @var string
@@ -100,6 +112,8 @@ class FileUploader implements JsonI {
         $this->files = [];
         $this->maxFileSize = null;
         $this->streamProcessor = null;
+        $this->onBeforeUpload = null;
+        $this->onAfterUpload = null;
         $this->setAssociatedFileName('files');
         $this->addExts($allowedTypes);
         $this->uploadDir = '';
@@ -339,6 +353,27 @@ class FileUploader implements JsonI {
      */
     public function getStreamProcessor(): ?callable {
         return $this->streamProcessor;
+    }
+    /**
+     * Sets a callback to be called before each file is uploaded.
+     *
+     * The callback receives the file info array. If it returns false,
+     * the file upload is rejected.
+     *
+     * @param callable|null $callback Signature: function(array $fileInfo): bool
+     */
+    public function setOnBeforeUpload(?callable $callback): void {
+        $this->onBeforeUpload = $callback;
+    }
+    /**
+     * Sets a callback to be called after each successful file upload.
+     *
+     * The callback receives the UploadedFile object.
+     *
+     * @param callable|null $callback Signature: function(UploadedFile $file): void
+     */
+    public function setOnAfterUpload(?callable $callback): void {
+        $this->onAfterUpload = $callback;
     }
     /**
      * Removes an extension from the array of allowed files types.
@@ -600,6 +635,10 @@ class FileUploader implements JsonI {
                     $fileInfoArr[UploaderConst::UPLOADED_INDEX] = false;
                     $fileInfoArr[UploaderConst::ERR_INDEX] = UploaderConst::ERR_FILE_TOO_LARGE;
                 } else if (File::isDirectory($this->getUploadDir())) {
+                    if ($this->onBeforeUpload !== null && ($this->onBeforeUpload)($fileInfoArr) === false) {
+                        $fileInfoArr[UploaderConst::UPLOADED_INDEX] = false;
+                        $fileInfoArr[UploaderConst::ERR_INDEX] = 'rejected_by_callback';
+                    } else {
                     $filePath = $this->getUploadDir().DIRECTORY_SEPARATOR.$fileInfoArr[UploaderConst::NAME_INDEX];
 
                     if (!File::isFileExist($filePath)) {
@@ -632,6 +671,7 @@ class FileUploader implements JsonI {
                             $fileInfoArr[UploaderConst::ERR_INDEX] = UploaderConst::ALREADY_EXIST;
                         }
                     }
+                    }
                 } else {
                     $fileInfoArr[UploaderConst::ERR_INDEX] = UploaderConst::ERR_NO_SUCH_DIR;
                     $fileInfoArr[UploaderConst::UPLOADED_INDEX] = false;
@@ -643,6 +683,10 @@ class FileUploader implements JsonI {
         } else {
             $fileInfoArr[UploaderConst::UPLOADED_INDEX] = false;
             $fileInfoArr[UploaderConst::ERR_INDEX] = $idx === null ? $fileOrFiles[$errIdx] : $fileOrFiles[$errIdx][$idx];
+        }
+
+        if ($fileInfoArr[UploaderConst::UPLOADED_INDEX] && $this->onAfterUpload !== null) {
+            ($this->onAfterUpload)($this->createFileObjFromArray($fileInfoArr));
         }
 
         return $fileInfoArr;

--- a/WebFiori/File/FileUploader.php
+++ b/WebFiori/File/FileUploader.php
@@ -267,7 +267,7 @@ class FileUploader implements JsonI {
      * Default value is true.
      * 
      * @return array An indexed array that contains sub associative arrays or 
-     * objects of type 'UploadFile'.
+     * objects of type FileInterface.
      * 
      * 
      */
@@ -510,7 +510,7 @@ class FileUploader implements JsonI {
      * @param bool $replaceIfExist If a file with the given name found
      * and this parameter is set to true, the file will be replaced.
      *
-     * @return array An array that contains objects of type 'UploadedFile'.
+     * @return array An array that contains objects of type FileInterface.
      *
      * @throws FileException
      */

--- a/WebFiori/File/FileUploader.php
+++ b/WebFiori/File/FileUploader.php
@@ -71,6 +71,12 @@ class FileUploader implements JsonI {
      */
     private $maxFileSize;
     /**
+     * Stream processor callable for upload processing.
+     * 
+     * @var callable|null
+     */
+    private $streamProcessor;
+    /**
      * Upload status message.
      * 
      * @var string
@@ -93,6 +99,7 @@ class FileUploader implements JsonI {
         $this->uploadStatusMessage = 'NO ACTION';
         $this->files = [];
         $this->maxFileSize = null;
+        $this->streamProcessor = null;
         $this->setAssociatedFileName('files');
         $this->addExts($allowedTypes);
         $this->uploadDir = '';
@@ -311,6 +318,27 @@ class FileUploader implements JsonI {
      */
     public function getMaxFileSizeLimit() : ?int {
         return $this->maxFileSize;
+    }
+    /**
+     * Sets a stream processor for upload processing.
+     *
+     * When set, uploaded files are streamed through this callable instead
+     * of using move_uploaded_file(). The callable receives a Generator of
+     * chunks and the destination path.
+     *
+     * @param callable|null $processor A callable with signature:
+     *        function(\Generator $chunks, string $destPath): void
+     */
+    public function setStreamProcessor(?callable $processor): void {
+        $this->streamProcessor = $processor;
+    }
+    /**
+     * Returns the current stream processor.
+     *
+     * @return callable|null
+     */
+    public function getStreamProcessor(): ?callable {
+        return $this->streamProcessor;
     }
     /**
      * Removes an extension from the array of allowed files types.
@@ -573,7 +601,6 @@ class FileUploader implements JsonI {
                     $fileInfoArr[UploaderConst::ERR_INDEX] = UploaderConst::ERR_FILE_TOO_LARGE;
                 } else if (File::isDirectory($this->getUploadDir())) {
                     $filePath = $this->getUploadDir().DIRECTORY_SEPARATOR.$fileInfoArr[UploaderConst::NAME_INDEX];
-                    $moveFunc = http_response_code() === false ? 'copy' : 'move_uploaded_file';
 
                     if (!File::isFileExist($filePath)) {
                         $fileInfoArr[UploaderConst::EXIST_INDEX] = false;
@@ -581,9 +608,7 @@ class FileUploader implements JsonI {
                         $name = $idx === null ? $fileOrFiles[$tempIdx] : $fileOrFiles[$tempIdx][$idx];
                         $sanitizedName = filter_var($name);
 
-
-
-                        if (!($moveFunc($sanitizedName, $filePath))) {
+                        if (!$this->moveFile($sanitizedName, $filePath)) {
                             $fileInfoArr[UploaderConst::ERR_INDEX] = UploaderConst::ERR_MOVE_TEMP;
                         } else {
                             $fileInfoArr[UploaderConst::UPLOADED_INDEX] = true;
@@ -595,9 +620,9 @@ class FileUploader implements JsonI {
                             $fileInfoArr[UploaderConst::REPLACE_INDEX] = true;
                             unlink($filePath);
                             $name = $idx === null ? $fileOrFiles[$tempIdx] : $fileOrFiles[$tempIdx][$idx];
-                            $sanitizedName = $sanitizedName = filter_var($name);
+                            $sanitizedName = filter_var($name);
 
-                            if ($moveFunc($sanitizedName, $filePath)) {
+                            if ($this->moveFile($sanitizedName, $filePath)) {
                                 $fileInfoArr[UploaderConst::UPLOADED_INDEX] = true;
                             } else {
                                 $fileInfoArr[UploaderConst::UPLOADED_INDEX] = false;
@@ -698,5 +723,32 @@ class FileUploader implements JsonI {
         $ext = pathinfo($fileName, PATHINFO_EXTENSION);
 
         return in_array($ext, $this->getExts(),true) || in_array(strtolower($ext), $this->getExts(),true);
+    }
+    /**
+     * Moves or streams a file from source to destination.
+     *
+     * If a stream processor is set, uses FileStream to pipe chunks through
+     * the processor. Otherwise uses move_uploaded_file or copy.
+     *
+     * @param string $source Source file path.
+     * @param string $dest Destination file path.
+     *
+     * @return bool True on success.
+     */
+    private function moveFile(string $source, string $dest): bool {
+        if ($this->streamProcessor !== null) {
+            try {
+                $stream = new FileStream($source);
+                ($this->streamProcessor)($stream->readChunks(), $dest);
+
+                return true;
+            } catch (\Throwable $e) {
+                return false;
+            }
+        }
+
+        $moveFunc = http_response_code() === false ? 'copy' : 'move_uploaded_file';
+
+        return $moveFunc($source, $dest);
     }
 }

--- a/WebFiori/File/FileUploader.php
+++ b/WebFiori/File/FileUploader.php
@@ -35,7 +35,7 @@ use WebFiori\Json\JsonI;
  * @author Ibrahim
  * 
  */
-class FileUploader implements JsonI {
+class FileUploader extends AbstractUploader implements JsonI {
     /**
      * The name of the index at which the file is stored in the array <b>$_FILES</b>.
      * 
@@ -44,50 +44,12 @@ class FileUploader implements JsonI {
      */
     private $asscociatedName;
     /**
-     * An array that contains all the allowed file types.
-     * 
-     * @var array An array of strings. 
-     * 
-     */
-    private $extensions = [];
-    /**
      * An array which contains uploaded files.
      * 
      * @var array
      * 
      */
     private $files;
-    /**
-     * The directory at which the file (or files) will be uploaded to.
-     * 
-     * @var string A directory. 
-     * 
-     */
-    private $uploadDir;
-    /**
-     * Custom maximum file size in bytes.
-     * 
-     * @var int|null
-     */
-    private $maxFileSize;
-    /**
-     * Stream processor callable for upload processing.
-     * 
-     * @var callable|null
-     */
-    private $streamProcessor;
-    /**
-     * Callback called before each file upload.
-     * 
-     * @var callable|null
-     */
-    private $onBeforeUpload;
-    /**
-     * Callback called after each successful file upload.
-     * 
-     * @var callable|null
-     */
-    private $onAfterUpload;
     /**
      * Upload status message.
      * 
@@ -108,19 +70,10 @@ class FileUploader implements JsonI {
      * @throws FileException
      */
     public function __construct(string $uploadPath = '', array $allowedTypes = []) {
+        parent::__construct($uploadPath, $allowedTypes);
         $this->uploadStatusMessage = 'NO ACTION';
         $this->files = [];
-        $this->maxFileSize = null;
-        $this->streamProcessor = null;
-        $this->onBeforeUpload = null;
-        $this->onAfterUpload = null;
         $this->setAssociatedFileName('files');
-        $this->addExts($allowedTypes);
-        $this->uploadDir = '';
-
-        if (strlen($uploadPath) != 0) {
-            $this->setUploadDir($uploadPath);
-        }
     }
     /**
      * Returns a JSON string that represents the object.
@@ -139,57 +92,6 @@ class FileUploader implements JsonI {
      */
     public function __toString() {
         return $this->toJSON().'';
-    }
-    /**
-     * Adds new extension to the array of allowed files types.
-     * 
-     * @param string $ext File extension (e.g. jpg, png, pdf).
-     * 
-     * @return bool If the extension is added, the method will return true.
-     * 
-     */
-    public function addExt(string $ext) : bool {
-        $ext = str_replace('.', '', $ext);
-        $len = strlen($ext);
-        $retVal = true;
-
-        if ($len != 0) {
-            for ($x = 0 ; $x < $len ; $x++) {
-                $ch = $ext[$x];
-
-                if (!($ch == '_' || ($ch >= 'a' && $ch <= 'z') || ($ch >= 'A' && $ch <= 'Z') || ($ch >= '0' && $ch <= '9'))) {
-                    $retVal = false;
-                    break;
-                }
-            }
-
-            if ($retVal === true) {
-                $this->extensions[] = $ext;
-            }
-        } else {
-            $retVal = false;
-        }
-
-        return $retVal;
-    }
-    /**
-     * Adds multiple extensions at once to the set of allowed files types.
-     * 
-     * @param array $arr An array of strings. Each string represents a file type.
-     * 
-     * @return array The method will return an associative array of booleans. 
-     * The key value will be the extension name and the value represents the status 
-     * of the addition. If added, it will be set to true.
-     * 
-     */
-    public function addExts(array $arr) : array {
-        $retVal = [];
-
-        foreach ($arr as $ext) {
-            $retVal[$ext] = $this->addExt($ext);
-        }
-
-        return $retVal;
     }
     /**
      * Adds a file to the array $_FILES for testing files uploads.
@@ -258,15 +160,6 @@ class FileUploader implements JsonI {
         return $this->asscociatedName;
     }
     /**
-     * Returns the array that contains all allowed file types.
-     * 
-     * @return array
-     * 
-     */
-    public function getExts() : array {
-        return $this->extensions;
-    }
-    /**
      * Returns an array which contains all information about the uploaded files.
      * 
      * The returned array will be indexed. At each index, a sub associative array 
@@ -307,120 +200,6 @@ class FileUploader implements JsonI {
         return $retVal;
     }
     /**
-     * Returns the directory at which the file or files will be uploaded to.
-     * 
-     * @return string upload directory. Default return value is empty string.
-     * 
-     */
-    public function getUploadDir() : string {
-        return $this->uploadDir;
-    }
-    /**
-     * Sets a custom maximum file size limit for this uploader instance.
-     * 
-     * @param int $bytes Maximum file size in bytes. Must be greater than 0.
-     */
-    public function setMaxFileSize(int $bytes) : void {
-        if ($bytes > 0) {
-            $this->maxFileSize = $bytes;
-        }
-    }
-    /**
-     * Returns the custom maximum file size limit.
-     * 
-     * @return int|null The limit in bytes, or null if no custom limit is set.
-     */
-    public function getMaxFileSizeLimit() : ?int {
-        return $this->maxFileSize;
-    }
-    /**
-     * Sets a stream processor for upload processing.
-     *
-     * When set, uploaded files are streamed through this callable instead
-     * of using move_uploaded_file(). The callable receives a Generator of
-     * chunks and the destination path.
-     *
-     * @param callable|null $processor A callable with signature:
-     *        function(\Generator $chunks, string $destPath): void
-     */
-    public function setStreamProcessor(?callable $processor): void {
-        $this->streamProcessor = $processor;
-    }
-    /**
-     * Returns the current stream processor.
-     *
-     * @return callable|null
-     */
-    public function getStreamProcessor(): ?callable {
-        return $this->streamProcessor;
-    }
-    /**
-     * Sets a callback to be called before each file is uploaded.
-     *
-     * The callback receives the file info array. If it returns false,
-     * the file upload is rejected.
-     *
-     * @param callable|null $callback Signature: function(array $fileInfo): bool
-     */
-    public function setOnBeforeUpload(?callable $callback): void {
-        $this->onBeforeUpload = $callback;
-    }
-    /**
-     * Sets a callback to be called after each successful file upload.
-     *
-     * The callback receives the UploadedFile object.
-     *
-     * @param callable|null $callback Signature: function(UploadedFile $file): void
-     */
-    public function setOnAfterUpload(?callable $callback): void {
-        $this->onAfterUpload = $callback;
-    }
-    /**
-     * Removes an extension from the array of allowed files types.
-     * 
-     * @param string $ext File extension= (e.g. jpg, png, pdf,...).
-     * 
-     * @return bool If the extension was removed, the method will return true.
-     * 
-     */
-    public function removeExt(string $ext) : bool {
-        $exts = $this->getExts();
-        $count = count($exts);
-        $retVal = false;
-        $temp = [];
-        $ext = str_replace('.', '', $ext);
-
-        for ($x = 0 ; $x < $count ; $x++) {
-            if ($exts[$x] != $ext) {
-                $temp[] = $exts[$x];
-            } else {
-                $retVal = true;
-            }
-        }
-        $this->extensions = $temp;
-
-        return $retVal;
-    }
-    /**
-     * Sanitizes an uploaded filename to prevent path traversal and filesystem issues.
-     *
-     * This method strips path separators, null bytes, and replaces special
-     * characters that could cause security vulnerabilities or filesystem problems.
-     *
-     * @param string $name The raw filename from the upload.
-     *
-     * @return string The sanitized filename safe for filesystem use.
-     */
-    public static function sanitizeFilename(string $name): string {
-        $name = str_replace("\\", "/", $name);
-        $name = basename($name);
-        $name = str_replace("\0", '', $name);
-        $name = preg_replace('/[^\w\-. ]/', '_', $name);
-        $name = ltrim($name, '.');
-
-        return $name;
-    }
-    /**
      * Sets The name of the index at which the file is stored in the array $_FILES.
      * 
      * This value is the value of the attribute 'name' in case of HTML file input. 
@@ -440,37 +219,6 @@ class FileUploader implements JsonI {
 
         if (strlen($trimmed) != 0) {
             $this->asscociatedName = $trimmed;
-        }
-    }
-    /**
-     * Sets the directory at which the file will be uploaded to.
-     * 
-     * This method will first check whether the directory is exist or not. then 
-     * it validate that the structure of the path is valid by replacing 
-     * forward slashes with backward slashes.
-     * 
-     * @param string $dir Upload Directory (such as '/files/uploads' or 
-     * 'C:/Server/uploads'). 
-     * 
-     * 
-     * @throws FileException If given directory is invalid or was not set.
-     * 
-     */
-    public function setUploadDir(string $dir) {
-        $fixedPath = File::fixPath($dir);
-
-        if (strlen($fixedPath) == 0) {
-            throw new FileException('Upload directory should not be an empty string.');
-        }
-
-        try {
-            if (!File::isDirectory($fixedPath)) {
-                throw new FileException('Invalid upload directory: '.$fixedPath);
-            }
-
-            $this->uploadDir = $fixedPath;
-        } catch (FileException $ex) {
-            throw new FileException('Invalid upload directory: '.$fixedPath);
         }
     }
     /**
@@ -631,11 +379,12 @@ class FileUploader implements JsonI {
 
         if (!$isErr) {
             if ($this->isValidExt($fileInfoArr[UploaderConst::NAME_INDEX])) {
-                if ($this->maxFileSize !== null && (int)$fileInfoArr[UploaderConst::SIZE_INDEX] > $this->maxFileSize) {
+                $maxSize = $this->getMaxFileSizeLimit();
+                if ($maxSize !== null && (int)$fileInfoArr[UploaderConst::SIZE_INDEX] > $maxSize) {
                     $fileInfoArr[UploaderConst::UPLOADED_INDEX] = false;
                     $fileInfoArr[UploaderConst::ERR_INDEX] = UploaderConst::ERR_FILE_TOO_LARGE;
                 } else if (File::isDirectory($this->getUploadDir())) {
-                    if ($this->onBeforeUpload !== null && ($this->onBeforeUpload)($fileInfoArr) === false) {
+                    if (!$this->fireBeforeUpload($fileInfoArr)) {
                         $fileInfoArr[UploaderConst::UPLOADED_INDEX] = false;
                         $fileInfoArr[UploaderConst::ERR_INDEX] = 'rejected_by_callback';
                     } else {
@@ -685,8 +434,8 @@ class FileUploader implements JsonI {
             $fileInfoArr[UploaderConst::ERR_INDEX] = $idx === null ? $fileOrFiles[$errIdx] : $fileOrFiles[$errIdx][$idx];
         }
 
-        if ($fileInfoArr[UploaderConst::UPLOADED_INDEX] && $this->onAfterUpload !== null) {
-            ($this->onAfterUpload)($this->createFileObjFromArray($fileInfoArr));
+        if ($fileInfoArr[UploaderConst::UPLOADED_INDEX]) {
+            $this->fireAfterUpload($this->createFileObjFromArray($fileInfoArr));
         }
 
         return $fileInfoArr;
@@ -755,20 +504,6 @@ class FileUploader implements JsonI {
         return true;
     }
     /**
-     * Checks if uploaded file is allowed or not.
-     * 
-     * @param string $fileName The name of the file (such as 'image.png')
-     * 
-     * @return bool If file extension is in the array of allowed types,
-     * the method will return true.
-     * 
-     */
-    private function isValidExt(string $fileName) : bool {
-        $ext = pathinfo($fileName, PATHINFO_EXTENSION);
-
-        return in_array($ext, $this->getExts(),true) || in_array(strtolower($ext), $this->getExts(),true);
-    }
-    /**
      * Moves or streams a file from source to destination.
      *
      * If a stream processor is set, uses FileStream to pipe chunks through
@@ -780,10 +515,11 @@ class FileUploader implements JsonI {
      * @return bool True on success.
      */
     private function moveFile(string $source, string $dest): bool {
-        if ($this->streamProcessor !== null) {
+        $processor = $this->getStreamProcessor();
+        if ($processor !== null) {
             try {
                 $stream = new FileStream($source);
-                ($this->streamProcessor)($stream->readChunks(), $dest);
+                $processor($stream->readChunks(), $dest);
 
                 return true;
             } catch (\Throwable $e) {

--- a/WebFiori/File/ResponseEmitter.php
+++ b/WebFiori/File/ResponseEmitter.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\File;
+
+/**
+ * An interface that abstracts HTTP output for file serving.
+ *
+ * Implementations handle setting headers, status codes, and sending
+ * the response body. This decouples file serving from any specific
+ * HTTP framework.
+ *
+ * @author Ibrahim
+ */
+interface ResponseEmitter {
+    /**
+     * Sets an HTTP response header.
+     *
+     * @param string $name Header name.
+     * @param string $value Header value.
+     */
+    public function setHeader(string $name, string $value): void;
+
+    /**
+     * Sets the HTTP response status code.
+     *
+     * @param int $code HTTP status code.
+     */
+    public function setStatusCode(int $code): void;
+
+    /**
+     * Sends the response body from a generator of chunks.
+     *
+     * @param \Generator $chunks A generator yielding string chunks.
+     */
+    public function sendBody(\Generator $chunks): void;
+}

--- a/WebFiori/File/StreamableInterface.php
+++ b/WebFiori/File/StreamableInterface.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\File;
+
+/**
+ * An interface that defines streaming file I/O operations.
+ *
+ * Implementations process files in constant memory using generators,
+ * making them suitable for large files that cannot be loaded entirely
+ * into memory.
+ *
+ * @author Ibrahim
+ */
+interface StreamableInterface {
+    /**
+     * Reads the file in fixed-size chunks.
+     *
+     * @param int $bufferSize The size of each chunk in bytes.
+     *
+     * @return \Generator Yields string chunks.
+     */
+    public function readChunks(int $bufferSize = 8192): \Generator;
+
+    /**
+     * Reads the file line by line.
+     *
+     * @return \Generator Yields one line at a time.
+     */
+    public function readLines(): \Generator;
+
+    /**
+     * Reads a specific byte range from the file.
+     *
+     * @param int $from Starting byte offset.
+     * @param int $to Ending byte offset.
+     * @param int $bufferSize The size of each chunk in bytes.
+     *
+     * @return \Generator Yields string chunks within the range.
+     */
+    public function readRange(int $from, int $to, int $bufferSize = 8192): \Generator;
+
+    /**
+     * Writes data from an iterable source to the file.
+     *
+     * @param iterable $source An iterable yielding string chunks.
+     * @param bool $append If true, appends to the file.
+     * @param bool $lock If true, acquires an exclusive lock during write.
+     */
+    public function writeFromStream(iterable $source, bool $append = true, bool $lock = true): void;
+
+    /**
+     * Serves the file over HTTP using a ResponseEmitter.
+     *
+     * @param bool $asAttachment If true, triggers download dialog.
+     * @param ResponseEmitter|null $emitter The emitter to use. If null, DefaultEmitter is used.
+     */
+    public function serve(bool $asAttachment = false, ?ResponseEmitter $emitter = null): void;
+
+    /**
+     * Returns the file size in bytes.
+     *
+     * @return int Size in bytes.
+     */
+    public function getSize(): int;
+
+    /**
+     * Returns the MIME type of the file.
+     *
+     * @return string MIME type.
+     */
+    public function getMIME(): string;
+
+    /**
+     * Returns the name of the file.
+     *
+     * @return string File name.
+     */
+    public function getName(): string;
+}

--- a/WebFiori/File/StreamingUploader.php
+++ b/WebFiori/File/StreamingUploader.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\File;
+
+use WebFiori\File\Exceptions\FileException;
+
+/**
+ * An uploader that receives a single file from php://input in constant memory.
+ *
+ * Unlike FileUploader which works with $_FILES (multipart form uploads),
+ * this class reads raw binary body data directly from the input stream,
+ * enabling large file uploads without temp file overhead.
+ *
+ * @author Ibrahim
+ */
+class StreamingUploader extends AbstractUploader {
+    /**
+     * @var string
+     */
+    private string $inputSource;
+
+    /**
+     * Creates a new StreamingUploader instance.
+     *
+     * @param string $uploadDir Directory to store uploaded files.
+     * @param array $allowedTypes Allowed file extensions.
+     * @param string $inputSource Input stream path (override for testing).
+     */
+    public function __construct(string $uploadDir = '', array $allowedTypes = [], string $inputSource = 'php://input') {
+        parent::__construct($uploadDir, $allowedTypes);
+        $this->inputSource = $inputSource;
+    }
+
+    /**
+     * Receives a file from the input stream and saves it to the upload directory.
+     *
+     * @param string|null $filename The filename to use. If null, attempts to
+     *        read from X-Filename header or Content-Disposition header.
+     *
+     * @return UploadedFile The uploaded file instance.
+     *
+     * @throws FileException If validation fails or the file cannot be written.
+     */
+    public function receive(?string $filename = null): UploadedFile {
+        if (strlen($this->getUploadDir()) === 0) {
+            throw new FileException('Upload path is not set.');
+        }
+
+        $filename = $this->resolveFilename($filename);
+        $filename = self::sanitizeFilename($filename);
+
+        if (strlen($filename) === 0) {
+            throw new FileException('Filename is empty after sanitization.');
+        }
+
+        if (count($this->getExts()) > 0 && !$this->isValidExt($filename)) {
+            throw new FileException('File type not allowed.');
+        }
+
+        // Early size check from Content-Length header
+        $maxSize = $this->getMaxFileSizeLimit();
+
+        if ($maxSize !== null && isset($_SERVER['CONTENT_LENGTH'])) {
+            if ((int) $_SERVER['CONTENT_LENGTH'] > $maxSize) {
+                throw new FileException('File exceeds size limit.');
+            }
+        }
+
+        $fileInfo = [
+            'name' => $filename,
+            'upload-path' => $this->getUploadDir(),
+        ];
+
+        if (!$this->fireBeforeUpload($fileInfo)) {
+            throw new FileException('Upload rejected by callback.');
+        }
+
+        $destPath = $this->getUploadDir() . DIRECTORY_SEPARATOR . $filename;
+        $chunks = $this->readInput();
+        $processor = $this->getStreamProcessor();
+
+        if ($processor !== null) {
+            $processor($chunks, $destPath);
+        } else {
+            file_put_contents($destPath, '');
+            $stream = new FileStream($destPath);
+            $stream->writeFromStream($chunks, false);
+        }
+
+        // Verify size after write
+        if ($maxSize !== null && File::isFileExist($destPath) && filesize($destPath) > $maxSize) {
+            unlink($destPath);
+            throw new FileException('File exceeds size limit.');
+        }
+
+        $file = new UploadedFile($filename, $this->getUploadDir());
+        $file->setIsUploaded(true);
+        $this->fireAfterUpload($file);
+
+        return $file;
+    }
+
+    /**
+     * Reads from the input source as a generator.
+     *
+     * @param int $bufferSize Buffer size in bytes.
+     *
+     * @return \Generator Yields string chunks.
+     *
+     * @throws FileException If unable to open input.
+     */
+    private function readInput(int $bufferSize = 8192): \Generator {
+        $input = @fopen($this->inputSource, 'rb');
+
+        if (!is_resource($input)) {
+            throw new FileException('Unable to open input stream.');
+        }
+
+        $maxSize = $this->getMaxFileSizeLimit();
+
+        try {
+            $bytesRead = 0;
+
+            while (!feof($input)) {
+                $chunk = fread($input, $bufferSize);
+
+                if ($chunk === false || strlen($chunk) === 0) {
+                    break;
+                }
+
+                $bytesRead += strlen($chunk);
+
+                if ($maxSize !== null && $bytesRead > $maxSize) {
+                    throw new FileException('File exceeds size limit.');
+                }
+
+                yield $chunk;
+            }
+        } finally {
+            fclose($input);
+        }
+    }
+
+    /**
+     * Resolves the filename from parameter, headers, or default.
+     *
+     * @param string|null $filename Explicit filename if provided.
+     *
+     * @return string Resolved filename.
+     */
+    private function resolveFilename(?string $filename): string {
+        if ($filename !== null && strlen($filename) > 0) {
+            return $filename;
+        }
+
+        if (isset($_SERVER['HTTP_X_FILENAME'])) {
+            return $_SERVER['HTTP_X_FILENAME'];
+        }
+
+        if (isset($_SERVER['HTTP_CONTENT_DISPOSITION'])) {
+            if (preg_match('/filename="?([^";\s]+)"?/', $_SERVER['HTTP_CONTENT_DISPOSITION'], $matches)) {
+                return $matches[1];
+            }
+        }
+
+        return 'upload.bin';
+    }
+}

--- a/WebFiori/File/WebFioriEmitter.php
+++ b/WebFiori/File/WebFioriEmitter.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2026 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\File;
+
+use WebFiori\Http\Response;
+
+/**
+ * A ResponseEmitter that wraps WebFiori\Http\Response for framework integration.
+ *
+ * @author Ibrahim
+ */
+class WebFioriEmitter implements ResponseEmitter {
+    private Response $response;
+
+    public function __construct(?Response $response = null) {
+        $this->response = $response ?? new Response();
+    }
+
+    public function setHeader(string $name, string $value): void {
+        $this->response->addHeader($name, $value);
+    }
+
+    public function setStatusCode(int $code): void {
+        $this->response->setCode($code);
+    }
+
+    public function sendBody(\Generator $chunks): void {
+        foreach ($chunks as $chunk) {
+            $this->response->write($chunk);
+        }
+    }
+
+    /**
+     * Returns the underlying Response object.
+     *
+     * @return Response
+     */
+    public function getResponse(): Response {
+        return $this->response;
+    }
+}

--- a/examples/atomic-write/README.md
+++ b/examples/atomic-write/README.md
@@ -1,0 +1,21 @@
+# Atomic Write
+
+Demonstrates `FileStream::writeAtomic()` for crash-safe file operations.
+
+## Features Shown
+
+- `writeAtomic(iterable)` — Write via temp file + rename
+- Streaming from another file atomically
+
+## Run
+
+```bash
+php examples/atomic-write/atomic-write.php
+```
+
+## Key Points
+
+- Data is written to a temp file first (`target.tmp.PID`)
+- `rename()` atomically swaps the temp into the target path
+- If a crash occurs mid-write, the original file is untouched
+- The temp file is cleaned up automatically on success or failure

--- a/examples/atomic-write/atomic-write.php
+++ b/examples/atomic-write/atomic-write.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Example: Atomic Write
+ * 
+ * Demonstrates using writeAtomic() for crash-safe file writes.
+ * Data is written to a temp file first, then atomically renamed.
+ */
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use WebFiori\File\FileStream;
+
+$tmpDir = __DIR__.'/../tmp';
+$targetPath = $tmpDir.'/config.json';
+
+// Create initial file
+file_put_contents($targetPath, '{"version": 1}');
+echo "Before: ".file_get_contents($targetPath)."\n";
+
+// --- Atomic write from an array ---
+$stream = new FileStream($targetPath);
+$stream->writeAtomic(['{"version": 2, "updated": true}']);
+echo "After:  ".file_get_contents($targetPath)."\n";
+
+// --- Atomic write by streaming from another file ---
+$sourcePath = $tmpDir.'/new-config.json';
+file_put_contents($sourcePath, '{"version": 3, "streamed": true}');
+
+$source = new FileStream($sourcePath);
+$target = new FileStream($targetPath);
+$target->writeAtomic($source->readChunks());
+echo "Final:  ".file_get_contents($targetPath)."\n";
+
+// Cleanup
+unlink($targetPath);
+unlink($sourcePath);

--- a/examples/copy-and-move/README.md
+++ b/examples/copy-and-move/README.md
@@ -1,0 +1,21 @@
+# Copy and Move Files
+
+Demonstrates `copy()` and `moveTo()` methods on the File class.
+
+## Features Shown
+
+- `copy(destination)` — Creates a copy, returns new File instance
+- `moveTo(destination)` — Moves file, updates current instance
+
+## Run
+
+```bash
+php examples/copy-and-move/copy-and-move.php
+```
+
+## Key Points
+
+- Both methods use streaming internally (constant memory for large files)
+- `moveTo()` tries `rename()` first (instant on same filesystem)
+- Parent directories are created automatically if needed
+- `copy()` returns a new `FileInterface` instance for the copy

--- a/examples/copy-and-move/copy-and-move.php
+++ b/examples/copy-and-move/copy-and-move.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Example: Copy and Move Files
+ * 
+ * Demonstrates using copy() and moveTo() for file operations.
+ * Both use streaming internally for constant memory usage.
+ */
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use WebFiori\File\File;
+
+$tmpDir = __DIR__.'/../tmp';
+
+// Create a source file
+$source = new File($tmpDir.'/original.txt');
+$source->create(true);
+$source->setRawData('Original content for copy/move demo.');
+$source->write(false);
+echo "Created: ".$source->getAbsolutePath()."\n";
+
+// --- Copy ---
+$copy = $source->copy($tmpDir.'/copied.txt');
+echo "\nCopied to: ".$copy->getAbsolutePath()."\n";
+echo "Copy exists: ".($copy->isExist() ? 'yes' : 'no')."\n";
+echo "Original still exists: ".($source->isExist() ? 'yes' : 'no')."\n";
+
+// --- Move ---
+$source->moveTo($tmpDir.'/moved.txt');
+echo "\nMoved to: ".$source->getAbsolutePath()."\n";
+echo "Old path exists: ".(file_exists($tmpDir.'/original.txt') ? 'yes' : 'no')."\n";
+echo "New path exists: ".($source->isExist() ? 'yes' : 'no')."\n";
+
+// Cleanup
+$copy->remove();
+$source->remove();

--- a/examples/serving-files/serving-files.php
+++ b/examples/serving-files/serving-files.php
@@ -1,36 +1,51 @@
 <?php
 
 /**
- * Example 13: Serving Files over HTTP
+ * Example: Serving Files over HTTP
  * 
- * Demonstrates using view() to serve files to the browser with proper
- * HTTP headers (Content-Type, Content-Disposition, Content-Range).
+ * Demonstrates serving files using view() and FileStream::serve()
+ * with ResponseEmitter for framework-agnostic HTTP output.
  * 
- * Run this with PHP's built-in server:
- *   php -S localhost:8080 examples/serving-files.php
- * 
- * Then visit:
- *   http://localhost:8080              (inline display)
- *   http://localhost:8080?download=1   (force download)
+ * Run with PHP's built-in server:
+ *   php -S localhost:8080 examples/serving-files/serving-files.php
  */
 require_once __DIR__.'/../../vendor/autoload.php';
 
 use WebFiori\File\File;
+use WebFiori\File\FileStream;
+use WebFiori\File\DefaultEmitter;
 
-// Create a sample file to serve
+// --- Method 1: File::view() (loads entire file into memory) ---
+echo "=== File::view() ===\n";
+
 $file = new File();
 $file->setName('example.txt');
-$file->setRawData("This is a sample file served by WebFiori File library.\nLine 2 of content.");
+$file->setRawData("This is a sample file served by WebFiori File library.\nLine 2.");
 
-// view(false) = display inline in browser (Content-Disposition: inline)
-// view(true)  = force download dialog  (Content-Disposition: attachment)
-$forceDownload = isset($_GET['download']);
-$file->view($forceDownload);
+// You can set a custom ResponseEmitter (default is DefaultEmitter)
+// $file->setResponseEmitter(new WebFioriEmitter()); // for WebFiori framework
+// $file->setResponseEmitter(new MyCustomEmitter()); // for your framework
 
-// The view() method automatically:
-// 1. Sets Content-Type based on MIME detection (text/plain for .txt)
-// 2. Sets Accept-Ranges: bytes (enables range requests for streaming)
-// 3. Sets Content-Length
-// 4. Sets Content-Disposition with the filename
-// 5. Handles HTTP_RANGE header for partial content (206 responses)
-// 6. Outputs the file data
+// view(false) = inline, view(true) = attachment (download)
+// Note: view() no longer calls die() by default
+// $file->view(false);
+
+echo "File ready to serve: ".$file->getName()." (".$file->getSize()." bytes)\n";
+
+// --- Method 2: FileStream::serve() (constant memory, for large files) ---
+echo "\n=== FileStream::serve() ===\n";
+
+$samplePath = __DIR__.'/../tmp/serve-demo.txt';
+file_put_contents($samplePath, "Streamed content - works for any file size.\n");
+
+$stream = new FileStream($samplePath);
+
+// serve() uses DefaultEmitter by default (raw header + echo + flush)
+// Pass a custom emitter for framework integration:
+// $stream->serve(false, new MyPsr7Emitter());
+
+echo "Stream ready to serve: ".$stream->getName()." (".$stream->getSize()." bytes)\n";
+echo "MIME: ".$stream->getMIME()."\n";
+
+// Cleanup
+unlink($samplePath);

--- a/examples/streaming-upload/README.md
+++ b/examples/streaming-upload/README.md
@@ -1,0 +1,23 @@
+# Streaming Upload (php://input)
+
+Demonstrates `StreamingUploader` for receiving files from raw HTTP body in constant memory.
+
+## Features Shown
+
+- Basic streaming upload from `php://input`
+- Hash verification during transfer via stream processor
+- Size limit enforcement during streaming (early rejection)
+
+## Run
+
+```bash
+php examples/streaming-upload/streaming-upload.php
+```
+
+## Key Points
+
+- Receives raw binary body (not multipart/form-data)
+- Client sends `Content-Type: application/octet-stream` with `X-Filename` header
+- Constant memory regardless of file size
+- Stream processor enables hash/encrypt/validate during transfer
+- Constructor accepts custom input source for testing

--- a/examples/streaming-upload/index.html
+++ b/examples/streaming-upload/index.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Streaming Upload - Pause/Resume</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: system-ui, sans-serif; max-width: 600px; margin: 40px auto; padding: 20px; }
+        h1 { margin-bottom: 20px; font-size: 1.4em; }
+        .drop-zone {
+            border: 2px dashed #ccc; border-radius: 8px; padding: 40px;
+            text-align: center; margin-bottom: 20px; cursor: pointer;
+            transition: border-color 0.2s;
+        }
+        .drop-zone:hover, .drop-zone.dragover { border-color: #4a90d9; }
+        input[type="file"] { display: none; }
+        .progress-container { display: none; margin-bottom: 20px; }
+        .progress-bar {
+            width: 100%; height: 24px; background: #eee; border-radius: 4px; overflow: hidden;
+        }
+        .progress-fill {
+            height: 100%; background: #4a90d9; transition: width 0.2s; width: 0%;
+        }
+        .progress-text { margin-top: 8px; font-size: 0.9em; color: #666; }
+        .controls { display: none; gap: 10px; margin-bottom: 20px; }
+        button {
+            padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer;
+            font-size: 0.95em; font-weight: 500;
+        }
+        .btn-pause { background: #f0ad4e; color: white; }
+        .btn-resume { background: #5cb85c; color: white; }
+        .btn-cancel { background: #d9534f; color: white; }
+        .btn-pause:disabled, .btn-resume:disabled { opacity: 0.5; cursor: not-allowed; }
+        .status { padding: 12px; border-radius: 4px; font-size: 0.9em; display: none; }
+        .status.success { display: block; background: #dff0d8; color: #3c763d; }
+        .status.error { display: block; background: #f2dede; color: #a94442; }
+        .stats { margin-top: 12px; font-size: 0.85em; color: #888; }
+    </style>
+</head>
+<body>
+    <h1>Streaming Upload with Pause/Resume</h1>
+
+    <div class="drop-zone" id="dropZone">
+        <p>Drop a file here or click to select</p>
+        <p style="font-size: 0.85em; color: #999; margin-top: 8px;">Supports any file size</p>
+        <input type="file" id="fileInput">
+    </div>
+
+    <div class="progress-container" id="progressContainer">
+        <div class="progress-bar"><div class="progress-fill" id="progressFill"></div></div>
+        <div class="progress-text" id="progressText">0%</div>
+    </div>
+
+    <div class="controls" id="controls">
+        <button class="btn-pause" id="btnPause" onclick="pauseUpload()">Pause</button>
+        <button class="btn-resume" id="btnResume" onclick="resumeUpload()" disabled>Resume</button>
+        <button class="btn-cancel" id="btnCancel" onclick="cancelUpload()">Cancel</button>
+    </div>
+
+    <div class="status" id="status"></div>
+    <div class="stats" id="stats"></div>
+
+    <script>
+    const CHUNK_SIZE = 1024 * 1024; // 1MB per chunk
+    const SERVER_URL = '/server.php';
+
+    let file = null;
+    let uploadId = null;
+    let currentChunk = 0;
+    let totalChunks = 0;
+    let paused = false;
+    let cancelled = false;
+    let startTime = 0;
+    let bytesUploaded = 0;
+
+    // Drop zone
+    const dropZone = document.getElementById('dropZone');
+    const fileInput = document.getElementById('fileInput');
+
+    dropZone.addEventListener('click', () => fileInput.click());
+    dropZone.addEventListener('dragover', e => { e.preventDefault(); dropZone.classList.add('dragover'); });
+    dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+    dropZone.addEventListener('drop', e => {
+        e.preventDefault();
+        dropZone.classList.remove('dragover');
+        if (e.dataTransfer.files.length) startUpload(e.dataTransfer.files[0]);
+    });
+    fileInput.addEventListener('change', () => {
+        if (fileInput.files.length) startUpload(fileInput.files[0]);
+    });
+
+    function startUpload(selectedFile) {
+        file = selectedFile;
+        uploadId = Date.now().toString(36) + Math.random().toString(36).slice(2);
+        currentChunk = 0;
+        totalChunks = Math.ceil(file.size / CHUNK_SIZE);
+        paused = false;
+        cancelled = false;
+        bytesUploaded = 0;
+        startTime = Date.now();
+
+        document.getElementById('progressContainer').style.display = 'block';
+        document.getElementById('controls').style.display = 'flex';
+        document.getElementById('status').className = 'status';
+        document.getElementById('stats').textContent = '';
+        document.getElementById('btnPause').disabled = false;
+        document.getElementById('btnResume').disabled = true;
+
+        dropZone.innerHTML = `<p><strong>${file.name}</strong></p><p style="color:#999">${formatSize(file.size)} — ${totalChunks} chunks</p>`;
+
+        sendNextChunk();
+    }
+
+    async function sendNextChunk() {
+        if (paused || cancelled || currentChunk >= totalChunks) return;
+
+        const start = currentChunk * CHUNK_SIZE;
+        const end = Math.min(start + CHUNK_SIZE, file.size);
+        const chunk = file.slice(start, end);
+
+        try {
+            const response = await fetch(SERVER_URL, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/octet-stream',
+                    'X-Filename': file.name,
+                    'X-Chunk-Index': currentChunk.toString(),
+                    'X-Total-Chunks': totalChunks.toString(),
+                    'X-Upload-Id': uploadId
+                },
+                body: chunk
+            });
+
+            if (!response.ok) throw new Error(`Server error: ${response.status}`);
+
+            const result = await response.json();
+            currentChunk++;
+            bytesUploaded = currentChunk * CHUNK_SIZE;
+
+            updateProgress();
+
+            if (result.complete) {
+                onComplete(result);
+            } else if (!paused && !cancelled) {
+                sendNextChunk();
+            }
+        } catch (err) {
+            showStatus('error', `Upload failed: ${err.message}`);
+        }
+    }
+
+    function pauseUpload() {
+        paused = true;
+        document.getElementById('btnPause').disabled = true;
+        document.getElementById('btnResume').disabled = false;
+        showStats('Paused');
+    }
+
+    function resumeUpload() {
+        paused = false;
+        document.getElementById('btnPause').disabled = false;
+        document.getElementById('btnResume').disabled = true;
+        showStats('Resuming...');
+        sendNextChunk();
+    }
+
+    function cancelUpload() {
+        cancelled = true;
+        paused = false;
+        document.getElementById('controls').style.display = 'none';
+        showStatus('error', 'Upload cancelled.');
+    }
+
+    function onComplete(result) {
+        document.getElementById('controls').style.display = 'none';
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        const speed = formatSize(file.size / (elapsed || 1)) + '/s';
+        showStatus('success',
+            `Upload complete: ${result.filename}<br>` +
+            `Size: ${formatSize(result.finalSize)}<br>` +
+            `SHA-256: <code>${result.sha256}</code><br>` +
+            `Time: ${elapsed}s (${speed})`
+        );
+    }
+
+    function updateProgress() {
+        const pct = Math.min(100, (currentChunk / totalChunks) * 100).toFixed(1);
+        document.getElementById('progressFill').style.width = pct + '%';
+        document.getElementById('progressText').textContent =
+            `${pct}% — Chunk ${currentChunk}/${totalChunks} — ${formatSize(bytesUploaded)} / ${formatSize(file.size)}`;
+
+        const elapsed = (Date.now() - startTime) / 1000;
+        const speed = bytesUploaded / (elapsed || 1);
+        const remaining = (file.size - bytesUploaded) / (speed || 1);
+        showStats(`Speed: ${formatSize(speed)}/s — ETA: ${remaining.toFixed(0)}s`);
+    }
+
+    function showStatus(type, msg) {
+        const el = document.getElementById('status');
+        el.className = 'status ' + type;
+        el.innerHTML = msg;
+    }
+
+    function showStats(msg) {
+        document.getElementById('stats').textContent = msg;
+    }
+
+    function formatSize(bytes) {
+        if (bytes >= 1073741824) return (bytes / 1073741824).toFixed(2) + ' GB';
+        if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + ' MB';
+        if (bytes >= 1024) return (bytes / 1024).toFixed(0) + ' KB';
+        return bytes + ' B';
+    }
+    </script>
+</body>
+</html>

--- a/examples/streaming-upload/router.php
+++ b/examples/streaming-upload/router.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Router for PHP built-in server.
+ * 
+ * Usage: php -S localhost:8080 examples/streaming-upload/router.php
+ * Then open: http://localhost:8080
+ */
+$uri = $_SERVER['REQUEST_URI'];
+
+if ($uri === '/server.php' || str_starts_with($uri, '/server.php?')) {
+    require __DIR__.'/server.php';
+    return true;
+}
+
+if ($uri === '/' || $uri === '/index.html') {
+    header('Content-Type: text/html');
+    readfile(__DIR__.'/index.html');
+    return true;
+}
+
+return false;

--- a/examples/streaming-upload/server.php
+++ b/examples/streaming-upload/server.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Streaming Upload Server
+ * 
+ * Receives chunked uploads from the frontend with pause/resume support.
+ * Each chunk is appended to the destination file as it arrives.
+ * 
+ * Run: php -S localhost:8080 examples/streaming-upload/server.php
+ */
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use WebFiori\File\Exceptions\FileException;
+use WebFiori\File\FileStream;
+use WebFiori\File\AbstractUploader;
+
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Headers: Content-Type, X-Filename, X-Chunk-Index, X-Total-Chunks, X-Upload-Id');
+header('Access-Control-Allow-Methods: POST, OPTIONS');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+$uploadDir = __DIR__.'/../tmp/stream-uploads';
+
+if (!is_dir($uploadDir)) {
+    mkdir($uploadDir, 0755, true);
+}
+
+$filename = $_SERVER['HTTP_X_FILENAME'] ?? 'upload.bin';
+$filename = AbstractUploader::sanitizeFilename($filename);
+$chunkIndex = (int)($_SERVER['HTTP_X_CHUNK_INDEX'] ?? 0);
+$totalChunks = (int)($_SERVER['HTTP_X_TOTAL_CHUNKS'] ?? 1);
+$uploadId = $_SERVER['HTTP_X_UPLOAD_ID'] ?? uniqid();
+
+$destPath = $uploadDir . DIRECTORY_SEPARATOR . $uploadId . '_' . $filename;
+
+try {
+    // Read chunk from php://input and append to file
+    $input = fopen('php://input', 'rb');
+
+    if (!is_resource($input)) {
+        throw new FileException('Unable to read input.');
+    }
+
+    $dest = fopen($destPath, 'ab'); // append mode
+    $bytesWritten = 0;
+
+    while (!feof($input)) {
+        $chunk = fread($input, 8192);
+
+        if ($chunk === false || strlen($chunk) === 0) {
+            break;
+        }
+
+        fwrite($dest, $chunk);
+        $bytesWritten += strlen($chunk);
+    }
+
+    fclose($input);
+    fclose($dest);
+
+    $complete = ($chunkIndex + 1) >= $totalChunks;
+
+    $response = [
+        'status' => 'ok',
+        'chunk' => $chunkIndex,
+        'totalChunks' => $totalChunks,
+        'bytesWritten' => $bytesWritten,
+        'complete' => $complete,
+        'filename' => $filename,
+    ];
+
+    if ($complete) {
+        $finalSize = filesize($destPath);
+        $response['finalSize'] = $finalSize;
+        $response['sha256'] = hash_file('sha256', $destPath);
+
+        // Rename to final name (remove upload ID prefix)
+        $finalPath = $uploadDir . DIRECTORY_SEPARATOR . $filename;
+
+        if (file_exists($finalPath)) {
+            unlink($finalPath);
+        }
+        rename($destPath, $finalPath);
+        $response['path'] = $finalPath;
+    }
+
+    header('Content-Type: application/json');
+    echo json_encode($response);
+} catch (\Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/examples/streaming-upload/streaming-upload.php
+++ b/examples/streaming-upload/streaming-upload.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Example: Streaming Upload (php://input)
+ * 
+ * Demonstrates using StreamingUploader to receive files from raw HTTP body
+ * in constant memory, with hash verification.
+ * 
+ * In production, the client sends:
+ *   fetch('/upload', {
+ *       method: 'POST',
+ *       headers: { 'Content-Type': 'application/octet-stream', 'X-Filename': 'video.mp4' },
+ *       body: file
+ *   });
+ * 
+ * For this CLI demo, we simulate the input with a local file.
+ */
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use WebFiori\File\StreamingUploader;
+
+$tmpDir = __DIR__.'/../tmp';
+
+if (!is_dir($tmpDir.'/uploads')) {
+    mkdir($tmpDir.'/uploads', 0755, true);
+}
+
+// Create a fake input file (simulates php://input)
+$inputPath = $tmpDir.'/fake-input.dat';
+file_put_contents($inputPath, str_repeat('A', 1024).'END'); // 1027 bytes
+
+// --- Basic streaming upload ---
+echo "=== Basic Upload ===\n";
+$uploader = new StreamingUploader($tmpDir.'/uploads', ['dat', 'bin'], $inputPath);
+$file = $uploader->receive('streamed-file.dat');
+echo "Uploaded: ".$file->getName()."\n";
+echo "Size:     ".filesize($file->getAbsolutePath())." bytes\n";
+$file->remove();
+
+// --- With hash verification ---
+echo "\n=== Upload with Hash Verification ===\n";
+$uploader2 = new StreamingUploader($tmpDir.'/uploads', [], $inputPath);
+$checksum = null;
+
+$uploader2->setStreamProcessor(function(\Generator $chunks, string $destPath) use (&$checksum) {
+    $hash = hash_init('sha256');
+    $dest = fopen($destPath, 'wb');
+
+    foreach ($chunks as $chunk) {
+        hash_update($hash, $chunk);
+        fwrite($dest, $chunk);
+    }
+
+    fclose($dest);
+    $checksum = hash_final($hash);
+});
+
+$file2 = $uploader2->receive('verified.bin');
+echo "Uploaded: ".$file2->getName()."\n";
+echo "SHA-256:  ".$checksum."\n";
+$file2->remove();
+
+// --- With size limit ---
+echo "\n=== Upload with Size Limit (reject) ===\n";
+$uploader3 = new StreamingUploader($tmpDir.'/uploads', [], $inputPath);
+$uploader3->setMaxFileSize(100); // Only allow 100 bytes
+
+try {
+    $uploader3->receive('too-large.bin');
+} catch (\WebFiori\File\Exceptions\FileException $e) {
+    echo "Rejected: ".$e->getMessage()."\n";
+}
+
+// Cleanup
+unlink($inputPath);
+@rmdir($tmpDir.'/uploads');

--- a/examples/streaming/README.md
+++ b/examples/streaming/README.md
@@ -1,0 +1,23 @@
+# Streaming File I/O
+
+Demonstrates `FileStream` for constant-memory file operations.
+
+## Features Shown
+
+- `readChunks()` — Read file in fixed-size chunks
+- `readLines()` — Read file line by line
+- `readRange()` — Read specific byte ranges
+- `File::stream()` — Bridge from File to FileStream
+
+## Run
+
+```bash
+php examples/streaming/streaming.php
+```
+
+## Key Points
+
+- Memory usage stays constant regardless of file size
+- Generators yield one chunk at a time — use `foreach`
+- `readChunks()` buffer size is configurable
+- `File::stream()` creates a FileStream from any File instance

--- a/examples/streaming/streaming.php
+++ b/examples/streaming/streaming.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Example: Streaming File I/O
+ * 
+ * Demonstrates using FileStream for constant-memory file operations:
+ * reading chunks, reading lines, reading byte ranges, and serving files.
+ */
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use WebFiori\File\File;
+use WebFiori\File\FileStream;
+
+// Create a sample file
+$samplePath = __DIR__.'/../tmp/stream-demo.txt';
+file_put_contents($samplePath, "Line 1: Hello\nLine 2: World\nLine 3: Stream\nLine 4: Demo\n");
+
+// --- Reading in chunks (constant memory) ---
+echo "=== Read Chunks (10 bytes each) ===\n";
+$stream = new FileStream($samplePath);
+$chunkNum = 0;
+
+foreach ($stream->readChunks(10) as $chunk) {
+    $chunkNum++;
+    echo "Chunk $chunkNum: ".json_encode($chunk)."\n";
+}
+
+// --- Reading line by line ---
+echo "\n=== Read Lines ===\n";
+foreach ($stream->readLines() as $line) {
+    echo "  ".rtrim($line)."\n";
+}
+
+// --- Reading a byte range ---
+echo "\n=== Read Range (bytes 0-13) ===\n";
+$data = '';
+foreach ($stream->readRange(0, 13) as $chunk) {
+    $data .= $chunk;
+}
+echo "  ".$data."\n"; // "Line 1: Hello"
+
+// --- File metadata ---
+echo "\n=== Metadata ===\n";
+echo "Name: ".$stream->getName()."\n";
+echo "MIME: ".$stream->getMIME()."\n";
+echo "Size: ".$stream->getSize()." bytes\n";
+
+// --- Bridge from File class ---
+echo "\n=== Bridge from File::stream() ===\n";
+$file = new File($samplePath);
+$fileStream = $file->stream(16); // 16-byte buffer
+echo "Buffer size: ".$fileStream->getBufferSize()."\n";
+
+// Cleanup
+unlink($samplePath);

--- a/examples/upload-callbacks/README.md
+++ b/examples/upload-callbacks/README.md
@@ -1,0 +1,21 @@
+# Upload Callback Hooks
+
+Demonstrates `setOnBeforeUpload()` and `setOnAfterUpload()` for validation and logging.
+
+## Features Shown
+
+- `setOnBeforeUpload(callback)` — Validate/reject before file is moved
+- `setOnAfterUpload(callback)` — Log/process after successful upload
+
+## Run
+
+```bash
+php examples/upload-callbacks/upload-callbacks.php
+```
+
+## Key Points
+
+- Before-upload callback receives the file info array
+- Return `false` from before-upload to reject the file
+- After-upload callback receives the `UploadedFile` object
+- Both hooks work with `FileUploader` and `StreamingUploader`

--- a/examples/upload-callbacks/upload-callbacks.php
+++ b/examples/upload-callbacks/upload-callbacks.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Example: Upload Callback Hooks
+ * 
+ * Demonstrates using onBeforeUpload and onAfterUpload callbacks
+ * for validation, logging, and post-processing.
+ */
+require_once __DIR__.'/../../vendor/autoload.php';
+
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+
+use WebFiori\File\FileUploader;
+use WebFiori\File\UploadedFile;
+
+$tmpDir = __DIR__.'/../tmp';
+$uploadDir = $tmpDir.'/hook-uploads';
+
+if (!is_dir($uploadDir)) {
+    mkdir($uploadDir, 0755, true);
+}
+
+// Create a sample file
+$samplePath = $tmpDir.'/hook-test.txt';
+file_put_contents($samplePath, 'Content for hook demo.');
+
+// --- Before-upload hook (validation) ---
+echo "=== Before-Upload Hook ===\n";
+
+$uploader = new FileUploader($uploadDir, ['txt']);
+$_SERVER['REQUEST_METHOD'] = 'POST';
+
+$uploader->setOnBeforeUpload(function(array $fileInfo) {
+    echo "  Checking: ".$fileInfo['name']."\n";
+    // Reject files with "blocked" in the name
+    if (str_contains($fileInfo['name'], 'blocked')) {
+        echo "  REJECTED\n";
+        return false;
+    }
+    echo "  ACCEPTED\n";
+    return true;
+});
+
+FileUploader::addTestFile('files', $samplePath, true);
+$result = $uploader->upload();
+echo "  Uploaded: ".($result[0]['uploaded'] ? 'yes' : 'no')."\n";
+
+// Cleanup first upload
+if ($result[0]['uploaded']) {
+    unlink($uploadDir.DS.$result[0]['name']);
+}
+
+// --- After-upload hook (logging/processing) ---
+echo "\n=== After-Upload Hook ===\n";
+
+$uploader2 = new FileUploader($uploadDir, ['txt']);
+
+$uploader2->setOnAfterUpload(function(UploadedFile $file) {
+    echo "  Logged upload: ".$file->getName()." at ".$file->getDir()."\n";
+    echo "  MIME: ".$file->getMIME()."\n";
+});
+
+FileUploader::addTestFile('files', $samplePath, true);
+$result2 = $uploader2->upload();
+echo "  Uploaded: ".($result2[0]['uploaded'] ? 'yes' : 'no')."\n";
+
+// Cleanup
+if ($result2[0]['uploaded']) {
+    unlink($uploadDir.DS.$result2[0]['name']);
+}
+unlink($samplePath);
+@rmdir($uploadDir);

--- a/tests/WebFiori/Framework/Test/File/FileStreamTest.php
+++ b/tests/WebFiori/Framework/Test/File/FileStreamTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace WebFiori\Framework\Test\File;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\File\DefaultEmitter;
+use WebFiori\File\Exceptions\FileException;
+use WebFiori\File\File;
+use WebFiori\File\FileStream;
+use WebFiori\File\ResponseEmitter;
+use WebFiori\File\StreamableInterface;
+
+class FileStreamTest extends TestCase {
+    private static string $testDir;
+    private static string $testFile;
+
+    public static function setUpBeforeClass(): void {
+        self::$testDir = ROOT_PATH . 'tests' . DS . 'tmp';
+        self::$testFile = self::$testDir . DS . 'stream-test.txt';
+        file_put_contents(self::$testFile, "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n");
+    }
+
+    public static function tearDownAfterClass(): void {
+        if (file_exists(self::$testFile)) {
+            unlink(self::$testFile);
+        }
+        // Clean up any other test files
+        foreach (glob(self::$testDir . DS . 'stream-*') as $f) {
+            unlink($f);
+        }
+    }
+    /**
+     * @test
+     */
+    public function testImplementsStreamableInterface() {
+        $stream = new FileStream(self::$testFile);
+        $this->assertInstanceOf(StreamableInterface::class, $stream);
+    }
+    /**
+     * @test
+     */
+    public function testConstructorEmptyPath() {
+        $this->expectException(FileException::class);
+        new FileStream('');
+    }
+    /**
+     * @test
+     */
+    public function testGetName() {
+        $stream = new FileStream(self::$testFile);
+        $this->assertEquals('stream-test.txt', $stream->getName());
+    }
+    /**
+     * @test
+     */
+    public function testGetMIME() {
+        $stream = new FileStream(self::$testFile);
+        $this->assertEquals('text/plain', $stream->getMIME());
+    }
+    /**
+     * @test
+     */
+    public function testGetSize() {
+        $stream = new FileStream(self::$testFile);
+        $this->assertEquals(filesize(self::$testFile), $stream->getSize());
+    }
+    /**
+     * @test
+     */
+    public function testGetSizeNonExistent() {
+        $stream = new FileStream(self::$testDir . DS . 'nonexistent.txt');
+        $this->assertEquals(0, $stream->getSize());
+    }
+    /**
+     * @test
+     */
+    public function testGetPath() {
+        $stream = new FileStream(self::$testFile);
+        $this->assertEquals(self::$testFile, $stream->getPath());
+    }
+    /**
+     * @test
+     */
+    public function testBufferSize() {
+        $stream = new FileStream(self::$testFile, 4096);
+        $this->assertEquals(4096, $stream->getBufferSize());
+        $stream->setBufferSize(1024);
+        $this->assertEquals(1024, $stream->getBufferSize());
+    }
+    /**
+     * @test
+     */
+    public function testBufferSizeInvalidFallsBack() {
+        $stream = new FileStream(self::$testFile, -1);
+        $this->assertEquals(8192, $stream->getBufferSize());
+        $stream->setBufferSize(0);
+        $this->assertEquals(8192, $stream->getBufferSize());
+    }
+    /**
+     * @test
+     */
+    public function testReadChunks() {
+        $stream = new FileStream(self::$testFile);
+        $data = '';
+
+        foreach ($stream->readChunks(10) as $chunk) {
+            $this->assertLessThanOrEqual(10, strlen($chunk));
+            $data .= $chunk;
+        }
+        $this->assertEquals(file_get_contents(self::$testFile), $data);
+    }
+    /**
+     * @test
+     */
+    public function testReadChunksLargeBuffer() {
+        $stream = new FileStream(self::$testFile);
+        $chunks = [];
+
+        foreach ($stream->readChunks(99999) as $chunk) {
+            $chunks[] = $chunk;
+        }
+        // Entire file in one chunk
+        $this->assertCount(1, $chunks);
+        $this->assertEquals(file_get_contents(self::$testFile), $chunks[0]);
+    }
+    /**
+     * @test
+     */
+    public function testReadChunksNonExistentFile() {
+        $stream = new FileStream(self::$testDir . DS . 'nonexistent.txt');
+        $this->expectException(FileException::class);
+        iterator_to_array($stream->readChunks());
+    }
+    /**
+     * @test
+     */
+    public function testReadLines() {
+        $stream = new FileStream(self::$testFile);
+        $lines = [];
+
+        foreach ($stream->readLines() as $line) {
+            $lines[] = $line;
+        }
+        $this->assertCount(5, $lines);
+        $this->assertEquals("Line 1\n", $lines[0]);
+        $this->assertEquals("Line 5\n", $lines[4]);
+    }
+    /**
+     * @test
+     */
+    public function testReadLinesNonExistentFile() {
+        $stream = new FileStream(self::$testDir . DS . 'nonexistent.txt');
+        $this->expectException(FileException::class);
+        iterator_to_array($stream->readLines());
+    }
+    /**
+     * @test
+     */
+    public function testReadRange() {
+        $stream = new FileStream(self::$testFile);
+        $data = '';
+
+        foreach ($stream->readRange(0, 6) as $chunk) {
+            $data .= $chunk;
+        }
+        $this->assertEquals('Line 1', $data);
+    }
+    /**
+     * @test
+     */
+    public function testReadRangeMiddle() {
+        $stream = new FileStream(self::$testFile);
+        $content = file_get_contents(self::$testFile);
+        $data = '';
+
+        foreach ($stream->readRange(7, 13) as $chunk) {
+            $data .= $chunk;
+        }
+        $this->assertEquals(substr($content, 7, 6), $data);
+    }
+    /**
+     * @test
+     */
+    public function testReadRangeSmallBuffer() {
+        $stream = new FileStream(self::$testFile);
+        $data = '';
+
+        foreach ($stream->readRange(0, 10, 3) as $chunk) {
+            $this->assertLessThanOrEqual(3, strlen($chunk));
+            $data .= $chunk;
+        }
+        $this->assertEquals(substr(file_get_contents(self::$testFile), 0, 10), $data);
+    }
+    /**
+     * @test
+     */
+    public function testReadRangeInvalidFrom() {
+        $stream = new FileStream(self::$testFile);
+        $this->expectException(FileException::class);
+        iterator_to_array($stream->readRange(-1, 10));
+    }
+    /**
+     * @test
+     */
+    public function testReadRangeInvalidToLessThanFrom() {
+        $stream = new FileStream(self::$testFile);
+        $this->expectException(FileException::class);
+        iterator_to_array($stream->readRange(10, 5));
+    }
+    /**
+     * @test
+     */
+    public function testWriteFromStream() {
+        $dest = self::$testDir . DS . 'stream-write-test.txt';
+        $source = new FileStream(self::$testFile);
+        $target = new FileStream($dest);
+
+        // Create the destination file first
+        file_put_contents($dest, '');
+
+        $target->writeFromStream($source->readChunks(), false);
+        $this->assertEquals(file_get_contents(self::$testFile), file_get_contents($dest));
+        unlink($dest);
+    }
+    /**
+     * @test
+     */
+    public function testWriteFromStreamAppend() {
+        $dest = self::$testDir . DS . 'stream-append-test.txt';
+        file_put_contents($dest, 'EXISTING');
+
+        $target = new FileStream($dest);
+        $target->writeFromStream(['_APPENDED'], true);
+
+        $this->assertEquals('EXISTING_APPENDED', file_get_contents($dest));
+        unlink($dest);
+    }
+    /**
+     * @test
+     */
+    public function testWriteFromStreamNoLock() {
+        $dest = self::$testDir . DS . 'stream-nolock-test.txt';
+        file_put_contents($dest, '');
+
+        $target = new FileStream($dest);
+        $target->writeFromStream(['data'], false, false);
+
+        $this->assertEquals('data', file_get_contents($dest));
+        unlink($dest);
+    }
+    /**
+     * @test
+     */
+    public function testWriteFromArray() {
+        $dest = self::$testDir . DS . 'stream-array-test.txt';
+        file_put_contents($dest, '');
+
+        $target = new FileStream($dest);
+        $target->writeFromStream(['chunk1', 'chunk2', 'chunk3'], false);
+
+        $this->assertEquals('chunk1chunk2chunk3', file_get_contents($dest));
+        unlink($dest);
+    }
+    /**
+     * @test
+     */
+    public function testServe() {
+        $stream = new FileStream(self::$testFile);
+        $emitter = new TestEmitter();
+        $stream->serve(false, $emitter);
+
+        $this->assertEquals(200, $emitter->statusCode);
+        $this->assertEquals('text/plain', $emitter->headers['Content-Type']);
+        $this->assertEquals('inline; filename="stream-test.txt"', $emitter->headers['Content-Disposition']);
+        $this->assertEquals((string) filesize(self::$testFile), $emitter->headers['Content-Length']);
+        $this->assertEquals(file_get_contents(self::$testFile), $emitter->body);
+    }
+    /**
+     * @test
+     */
+    public function testServeAsAttachment() {
+        $stream = new FileStream(self::$testFile);
+        $emitter = new TestEmitter();
+        $stream->serve(true, $emitter);
+
+        $this->assertEquals('attachment; filename="stream-test.txt"', $emitter->headers['Content-Disposition']);
+    }
+    /**
+     * @test
+     */
+    public function testServeNonExistentFile() {
+        $stream = new FileStream(self::$testDir . DS . 'nonexistent.txt');
+        $this->expectException(FileException::class);
+        $stream->serve();
+    }
+    /**
+     * @test
+     */
+    public function testFileBridgeMethod() {
+        $file = new File('stream-test.txt', self::$testDir);
+        $stream = $file->stream();
+        $this->assertInstanceOf(FileStream::class, $stream);
+        $this->assertEquals('stream-test.txt', $stream->getName());
+    }
+    /**
+     * @test
+     */
+    public function testFileBridgeMethodCustomBuffer() {
+        $file = new File('stream-test.txt', self::$testDir);
+        $stream = $file->stream(2048);
+        $this->assertEquals(2048, $stream->getBufferSize());
+    }
+}
+
+/**
+ * A test emitter that captures output instead of sending it.
+ */
+class TestEmitter implements ResponseEmitter {
+    public array $headers = [];
+    public int $statusCode = 0;
+    public string $body = '';
+
+    public function setHeader(string $name, string $value): void {
+        $this->headers[$name] = $value;
+    }
+
+    public function setStatusCode(int $code): void {
+        $this->statusCode = $code;
+    }
+
+    public function sendBody(\Generator $chunks): void {
+        foreach ($chunks as $chunk) {
+            $this->body .= $chunk;
+        }
+    }
+}

--- a/tests/WebFiori/Framework/Test/File/FileStreamTest.php
+++ b/tests/WebFiori/Framework/Test/File/FileStreamTest.php
@@ -313,15 +313,67 @@ class FileStreamTest extends TestCase {
     /**
      * @test
      */
-    public function testWriteAtomic() {
-        $dest = self::$testDir . DS . 'stream-atomic-test.txt';
-        file_put_contents($dest, 'original');
-
-        $target = new FileStream($dest);
-        $target->writeAtomic(['new content']);
-
-        $this->assertEquals('new content', file_get_contents($dest));
-        unlink($dest);
+    public function testReadChunksEmptyFile() {
+        $emptyFile = self::$testDir . DS . 'stream-empty.txt';
+        file_put_contents($emptyFile, '');
+        $stream = new FileStream($emptyFile);
+        $chunks = iterator_to_array($stream->readChunks());
+        $this->assertCount(0, $chunks);
+        unlink($emptyFile);
+    }
+    /**
+     * @test
+     */
+    public function testReadLinesWindowsEndings() {
+        $winFile = self::$testDir . DS . 'stream-crlf.txt';
+        file_put_contents($winFile, "Line A\r\nLine B\r\nLine C\r\n");
+        $stream = new FileStream($winFile);
+        $lines = iterator_to_array($stream->readLines());
+        $this->assertCount(3, $lines);
+        $this->assertEquals("Line A\r\n", $lines[0]);
+        $this->assertEquals("Line C\r\n", $lines[2]);
+        unlink($winFile);
+    }
+    /**
+     * @test
+     */
+    public function testReadLinesNoTrailingNewline() {
+        $noNewline = self::$testDir . DS . 'stream-nonewline.txt';
+        file_put_contents($noNewline, "AAA\nBBB");
+        $stream = new FileStream($noNewline);
+        $lines = iterator_to_array($stream->readLines());
+        $this->assertCount(2, $lines);
+        $this->assertEquals("AAA\n", $lines[0]);
+        $this->assertEquals("BBB", $lines[1]);
+        unlink($noNewline);
+    }
+    /**
+     * @test
+     */
+    public function testEarlyBreakClosesHandle() {
+        $stream = new FileStream(self::$testFile);
+        foreach ($stream->readChunks(2) as $chunk) {
+            break; // break after first chunk
+        }
+        // If handle wasn't closed, a subsequent read would still work
+        // (verifying no resource leak)
+        $data = '';
+        foreach ($stream->readChunks() as $chunk) {
+            $data .= $chunk;
+        }
+        $this->assertEquals(file_get_contents(self::$testFile), $data);
+    }
+    /**
+     * @test
+     */
+    public function testReadRangeEntireFile() {
+        $stream = new FileStream(self::$testFile);
+        $size = $stream->getSize();
+        $data = '';
+        foreach ($stream->readRange(0, $size) as $chunk) {
+            $data .= $chunk;
+        }
+        $this->assertEquals(file_get_contents(self::$testFile), $data);
     }
     /**
      * @test

--- a/tests/WebFiori/Framework/Test/File/FileStreamTest.php
+++ b/tests/WebFiori/Framework/Test/File/FileStreamTest.php
@@ -310,6 +310,65 @@ class FileStreamTest extends TestCase {
         $stream = $file->stream(2048);
         $this->assertEquals(2048, $stream->getBufferSize());
     }
+    /**
+     * @test
+     */
+    public function testWriteAtomic() {
+        $dest = self::$testDir . DS . 'stream-atomic-test.txt';
+        file_put_contents($dest, 'original');
+
+        $target = new FileStream($dest);
+        $target->writeAtomic(['new content']);
+
+        $this->assertEquals('new content', file_get_contents($dest));
+        unlink($dest);
+    }
+    /**
+     * @test
+     */
+    public function testWriteAtomicFromGenerator() {
+        $dest = self::$testDir . DS . 'stream-atomic-gen.txt';
+        file_put_contents($dest, '');
+
+        $source = new FileStream(self::$testFile);
+        $target = new FileStream($dest);
+        $target->writeAtomic($source->readChunks(5));
+
+        $this->assertEquals(file_get_contents(self::$testFile), file_get_contents($dest));
+        unlink($dest);
+    }
+    /**
+     * @test
+     */
+    public function testWriteAtomicNoTempLeft() {
+        $dest = self::$testDir . DS . 'stream-atomic-clean.txt';
+        file_put_contents($dest, '');
+
+        $target = new FileStream($dest);
+        $target->writeAtomic(['data']);
+
+        // Temp file should not exist after successful write
+        $this->assertFalse(file_exists($dest . '.tmp.' . getmypid()));
+        unlink($dest);
+    }
+    /**
+     * @test
+     */
+    public function testWriteAtomicPreservesOriginalOnFailure() {
+        $dest = self::$testDir . DS . 'stream-atomic-fail.txt';
+        file_put_contents($dest, 'preserved');
+
+        // Use an unwritable temp path to trigger failure
+        $stream = new FileStream('/nonexistent-dir/file.txt');
+        try {
+            $stream->writeAtomic(['fail']);
+        } catch (FileException $e) {
+            // expected
+        }
+        // Original file at $dest should be untouched since we targeted a different path
+        $this->assertEquals('preserved', file_get_contents($dest));
+        unlink($dest);
+    }
 }
 
 /**

--- a/tests/WebFiori/Framework/Test/File/FileTest.php
+++ b/tests/WebFiori/Framework/Test/File/FileTest.php
@@ -560,4 +560,46 @@ class FileTest extends TestCase {
         $this->assertNull($file->getSize());
         $this->assertFalse($file->hasKnownSize());
     }
+    /**
+     * @test
+     */
+    public function testCopy() {
+        $src = ROOT_PATH.DS.'tests'.DS.'files'.DS.'text-file.txt';
+        $dest = ROOT_PATH.DS.'tests'.DS.'tmp'.DS.'copy-test.txt';
+        $file = new File($src);
+        $copy = $file->copy($dest);
+        $this->assertTrue($copy->isExist());
+        $this->assertEquals('copy-test.txt', $copy->getName());
+        $copy->remove();
+    }
+    /**
+     * @test
+     */
+    public function testCopyNonExistent() {
+        $this->expectException(FileException::class);
+        $file = new File('nonexistent.txt', ROOT_PATH.DS.'tests'.DS.'tmp');
+        $file->copy(ROOT_PATH.DS.'tests'.DS.'tmp'.DS.'dest.txt');
+    }
+    /**
+     * @test
+     */
+    public function testMoveTo() {
+        $src = ROOT_PATH.DS.'tests'.DS.'tmp'.DS.'move-src.txt';
+        $dest = ROOT_PATH.DS.'tests'.DS.'tmp'.DS.'move-dest.txt';
+        file_put_contents($src, 'move test');
+        $file = new File($src);
+        $file->moveTo($dest);
+        $this->assertFalse(file_exists($src));
+        $this->assertTrue($file->isExist());
+        $this->assertEquals('move-dest.txt', $file->getName());
+        $file->remove();
+    }
+    /**
+     * @test
+     */
+    public function testMoveToNonExistent() {
+        $this->expectException(FileException::class);
+        $file = new File('nonexistent.txt', ROOT_PATH.DS.'tests'.DS.'tmp');
+        $file->moveTo(ROOT_PATH.DS.'tests'.DS.'tmp'.DS.'dest.txt');
+    }
 }

--- a/tests/WebFiori/Framework/Test/File/FileTest.php
+++ b/tests/WebFiori/Framework/Test/File/FileTest.php
@@ -436,68 +436,35 @@ class FileTest extends TestCase {
      * @test
      */
     public function testView00() {
-        if (!class_exists('WebFiori\Http\Response')) {
-            $this->markTestSkipped('Class WebFiori\Http\Response is required for this test.');
-        }
         $file = new File('super.txt');
         $file->setRawData('Hello world!');
+        $emitter = new \WebFiori\Framework\Test\File\TestEmitter();
+        $file->setResponseEmitter($emitter);
         $file->view();
-        $response = $file->getResponse();
-        $this->assertNotNull($response);
-        $this->assertEquals([
-            'text/plain'
-        ], $response->getHeader('content-type'));
-        $this->assertEquals('Hello world!', $response->getBody());
-        $this->assertEquals([
-                'bytes'
-        ], $response->getHeader('accept-ranges'));
-        $this->assertEquals([
-                $file->getSize()
-        ], $response->getHeader('content-length'));
-        $this->assertEquals([
-                'inline; filename="super.txt"'
-        ], $response->getHeader('content-disposition'));
-        
+        $this->assertEquals('text/plain', $emitter->headers['Content-Type']);
+        $this->assertEquals('Hello world!', $emitter->body);
+        $this->assertEquals('bytes', $emitter->headers['Accept-Ranges']);
+        $this->assertEquals((string)$file->getSize(), $emitter->headers['Content-Length']);
+        $this->assertEquals('inline; filename="super.txt"', $emitter->headers['Content-Disposition']);
+
+        $emitter2 = new \WebFiori\Framework\Test\File\TestEmitter();
+        $file->setResponseEmitter($emitter2);
         $file->view(true);
-        $response = $file->getResponse();
-        $this->assertEquals([
-                'text/plain'
-        ], $response->getHeader('content-type'));
-        $this->assertEquals([
-                'bytes'
-        ], $response->getHeader('accept-ranges'));
-        $this->assertEquals([
-                $file->getSize()
-        ], $response->getHeader('content-length'));
-        $this->assertEquals([
-                'attachment; filename="super.txt"'
-        ], $response->getHeader('content-disposition'));
+        $this->assertEquals('attachment; filename="super.txt"', $emitter2->headers['Content-Disposition']);
     }
     /**
      * @test
      */
     public function testView01() {
-        if (!class_exists('WebFiori\Http\Response')) {
-            $this->markTestSkipped('Class WebFiori\Http\Response is required for this test.');
-        }
-        $file = new File('text-file-2.txt',ROOT_PATH.DS.'tests'.DS.'files');
+        $file = new File('text-file-2.txt', ROOT_PATH.DS.'tests'.DS.'files');
+        $emitter = new \WebFiori\Framework\Test\File\TestEmitter();
+        $file->setResponseEmitter($emitter);
         $file->view();
-        $response = $file->getResponse();
-        $this->assertNotNull($response);
-        $this->assertEquals('Testing the class \'File\'.', $response->getBody());
-        
-        $this->assertEquals([
-                'text/plain'
-        ], $response->getHeader('content-type'));
-        $this->assertEquals([
-                'bytes'
-        ], $response->getHeader('accept-ranges'));
-        $this->assertEquals([
-                $file->getSize()
-        ], $response->getHeader('content-length'));
-        $this->assertEquals([
-                'inline; filename="text-file-2.txt"'
-        ], $response->getHeader('content-disposition'));
+        $this->assertEquals("Testing the class 'File'.", $emitter->body);
+        $this->assertEquals('text/plain', $emitter->headers['Content-Type']);
+        $this->assertEquals('bytes', $emitter->headers['Accept-Ranges']);
+        $this->assertEquals((string)$file->getSize(), $emitter->headers['Content-Length']);
+        $this->assertEquals('inline; filename="text-file-2.txt"', $emitter->headers['Content-Disposition']);
     }
     /**
      * @test

--- a/tests/WebFiori/Framework/Test/File/StreamingUploaderTest.php
+++ b/tests/WebFiori/Framework/Test/File/StreamingUploaderTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace WebFiori\Framework\Test\File;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\File\AbstractUploader;
+use WebFiori\File\Exceptions\FileException;
+use WebFiori\File\StreamingUploader;
+use WebFiori\File\UploadedFile;
+
+class StreamingUploaderTest extends TestCase {
+    private static string $testDir;
+    private static string $inputFile;
+
+    public static function setUpBeforeClass(): void {
+        self::$testDir = ROOT_PATH . 'tests' . DS . 'tmp';
+        self::$inputFile = self::$testDir . DS . 'streaming-input.bin';
+        file_put_contents(self::$inputFile, 'streaming upload content');
+    }
+
+    public static function tearDownAfterClass(): void {
+        if (file_exists(self::$inputFile)) {
+            unlink(self::$inputFile);
+        }
+        foreach (glob(self::$testDir . DS . 'streamed-*') as $f) {
+            unlink($f);
+        }
+    }
+    /**
+     * @test
+     */
+    public function testExtendsAbstractUploader() {
+        $u = new StreamingUploader(self::$testDir, ['txt'], self::$inputFile);
+        $this->assertInstanceOf(AbstractUploader::class, $u);
+    }
+    /**
+     * @test
+     */
+    public function testReceiveBasic() {
+        $u = new StreamingUploader(self::$testDir, [], self::$inputFile);
+        $file = $u->receive('streamed-basic.txt');
+        $this->assertInstanceOf(UploadedFile::class, $file);
+        $this->assertEquals('streamed-basic.txt', $file->getName());
+        $this->assertTrue($file->isUploaded());
+        $this->assertEquals('streaming upload content', file_get_contents($file->getAbsolutePath()));
+        $file->remove();
+    }
+    /**
+     * @test
+     */
+    public function testReceiveNoUploadDir() {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('Upload path is not set.');
+        $u = new StreamingUploader('', [], self::$inputFile);
+        $u->receive('test.txt');
+    }
+    /**
+     * @test
+     */
+    public function testReceiveInvalidExtension() {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('File type not allowed.');
+        $u = new StreamingUploader(self::$testDir, ['png'], self::$inputFile);
+        $u->receive('streamed-invalid.txt');
+    }
+    /**
+     * @test
+     */
+    public function testReceiveAllowedExtension() {
+        $u = new StreamingUploader(self::$testDir, ['txt'], self::$inputFile);
+        $file = $u->receive('streamed-allowed.txt');
+        $this->assertTrue($file->isUploaded());
+        $file->remove();
+    }
+    /**
+     * @test
+     */
+    public function testReceiveExceedsSizeLimit() {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('File exceeds size limit.');
+        $u = new StreamingUploader(self::$testDir, [], self::$inputFile);
+        $u->setMaxFileSize(5); // 5 bytes, content is 24
+        $u->receive('streamed-toobig.txt');
+    }
+    /**
+     * @test
+     */
+    public function testReceiveWithinSizeLimit() {
+        $u = new StreamingUploader(self::$testDir, [], self::$inputFile);
+        $u->setMaxFileSize(1024);
+        $file = $u->receive('streamed-sizeok.txt');
+        $this->assertTrue($file->isUploaded());
+        $file->remove();
+    }
+    /**
+     * @test
+     */
+    public function testReceiveWithStreamProcessor() {
+        $u = new StreamingUploader(self::$testDir, [], self::$inputFile);
+        $hashResult = null;
+
+        $u->setStreamProcessor(function(\Generator $chunks, string $destPath) use (&$hashResult) {
+            $hash = hash_init('sha256');
+            $dest = fopen($destPath, 'wb');
+            foreach ($chunks as $chunk) {
+                hash_update($hash, $chunk);
+                fwrite($dest, $chunk);
+            }
+            fclose($dest);
+            $hashResult = hash_final($hash);
+        });
+
+        $file = $u->receive('streamed-hashed.txt');
+        $this->assertNotNull($hashResult);
+        $this->assertEquals(hash('sha256', 'streaming upload content'), $hashResult);
+        $file->remove();
+    }
+    /**
+     * @test
+     */
+    public function testReceiveBeforeCallbackRejects() {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('Upload rejected by callback.');
+        $u = new StreamingUploader(self::$testDir, [], self::$inputFile);
+        $u->setOnBeforeUpload(function(array $info) {
+            return false;
+        });
+        $u->receive('streamed-rejected.txt');
+    }
+    /**
+     * @test
+     */
+    public function testReceiveAfterCallback() {
+        $u = new StreamingUploader(self::$testDir, [], self::$inputFile);
+        $called = null;
+
+        $u->setOnAfterUpload(function(UploadedFile $file) use (&$called) {
+            $called = $file->getName();
+        });
+
+        $file = $u->receive('streamed-after.txt');
+        $this->assertEquals('streamed-after.txt', $called);
+        $file->remove();
+    }
+    /**
+     * @test
+     */
+    public function testReceiveFromXFilenameHeader() {
+        $_SERVER['HTTP_X_FILENAME'] = 'header-name.txt';
+        $u = new StreamingUploader(self::$testDir, [], self::$inputFile);
+        $file = $u->receive();
+        $this->assertEquals('header-name.txt', $file->getName());
+        $file->remove();
+        unset($_SERVER['HTTP_X_FILENAME']);
+    }
+    /**
+     * @test
+     */
+    public function testReceiveDefaultFilename() {
+        $u = new StreamingUploader(self::$testDir, [], self::$inputFile);
+        $file = $u->receive();
+        $this->assertEquals('upload.bin', $file->getName());
+        $file->remove();
+    }
+    /**
+     * @test
+     */
+    public function testReceiveSanitizesFilename() {
+        $u = new StreamingUploader(self::$testDir, [], self::$inputFile);
+        $file = $u->receive('../../evil<script>.txt');
+        $this->assertEquals('evil_script_.txt', $file->getName());
+        $file->remove();
+    }
+    /**
+     * @test
+     */
+    public function testReceiveEmptyFilenameAfterSanitize() {
+        $this->expectException(FileException::class);
+        $this->expectExceptionMessage('Filename is empty after sanitization.');
+        $u = new StreamingUploader(self::$testDir, [], self::$inputFile);
+        $u->receive('...');
+    }
+}

--- a/tests/WebFiori/Framework/Test/File/UploaderTest.php
+++ b/tests/WebFiori/Framework/Test/File/UploaderTest.php
@@ -350,4 +350,57 @@ class UploaderTest extends TestCase {
         $r = $u->upload();
         $this->assertFalse($r[0]['uploaded']);
     }
+    /**
+     * @test
+     */
+    public function testOnBeforeUploadAccept() {
+        $_SERVER['REQUEST_METHOD'] = 'post';
+        $u = new FileUploader(__DIR__, ['txt']);
+        $called = false;
+
+        $u->setOnBeforeUpload(function(array $info) use (&$called) {
+            $called = true;
+            return true;
+        });
+
+        FileUploader::addTestFile('files', ROOT_PATH.'tests'.DS.'tmp'.DS.'testUpload.txt', true);
+        $r = $u->upload();
+        $this->assertTrue($called);
+        $this->assertTrue($r[0]['uploaded']);
+        $u->getFiles(true)[0]->remove();
+    }
+    /**
+     * @test
+     */
+    public function testOnBeforeUploadReject() {
+        $_SERVER['REQUEST_METHOD'] = 'post';
+        $u = new FileUploader(__DIR__, ['txt']);
+
+        $u->setOnBeforeUpload(function(array $info) {
+            return false;
+        });
+
+        FileUploader::addTestFile('files', ROOT_PATH.'tests'.DS.'tmp'.DS.'testUpload.txt', true);
+        $r = $u->upload();
+        $this->assertFalse($r[0]['uploaded']);
+        $this->assertEquals('rejected_by_callback', $r[0]['upload-error']);
+    }
+    /**
+     * @test
+     */
+    public function testOnAfterUpload() {
+        $_SERVER['REQUEST_METHOD'] = 'post';
+        $u = new FileUploader(__DIR__, ['txt']);
+        $uploadedFile = null;
+
+        $u->setOnAfterUpload(function(UploadedFile $file) use (&$uploadedFile) {
+            $uploadedFile = $file;
+        });
+
+        FileUploader::addTestFile('files', ROOT_PATH.'tests'.DS.'tmp'.DS.'testUpload.txt', true);
+        $u->upload();
+        $this->assertNotNull($uploadedFile);
+        $this->assertEquals('testUpload.txt', $uploadedFile->getName());
+        $uploadedFile->remove();
+    }
 }

--- a/tests/WebFiori/Framework/Test/File/UploaderTest.php
+++ b/tests/WebFiori/Framework/Test/File/UploaderTest.php
@@ -294,4 +294,60 @@ class UploaderTest extends TestCase {
         $u->setMaxFileSize(-100);
         $this->assertNull($u->getMaxFileSizeLimit());
     }
+    /**
+     * @test
+     */
+    public function testStreamProcessorDefault() {
+        $u = new FileUploader(__DIR__, ['txt']);
+        $this->assertNull($u->getStreamProcessor());
+    }
+    /**
+     * @test
+     */
+    public function testStreamProcessorUpload() {
+        $_SERVER['REQUEST_METHOD'] = 'post';
+        $u = new FileUploader(__DIR__, ['txt']);
+        $hashResult = null;
+
+        $u->setStreamProcessor(function(\Generator $chunks, string $destPath) use (&$hashResult) {
+            $hash = hash_init('sha256');
+            $dest = fopen($destPath, 'wb');
+
+            foreach ($chunks as $chunk) {
+                hash_update($hash, $chunk);
+                fwrite($dest, $chunk);
+            }
+
+            fclose($dest);
+            $hashResult = hash_final($hash);
+        });
+
+        $this->assertNotNull($u->getStreamProcessor());
+        FileUploader::addTestFile('files', ROOT_PATH.'tests'.DS.'tmp'.DS.'testUpload.txt', true);
+        $r = $u->upload();
+        $this->assertTrue($r[0]['uploaded']);
+        $this->assertNotNull($hashResult);
+        $this->assertEquals(
+            hash('sha256', file_get_contents(ROOT_PATH.'tests'.DS.'tmp'.DS.'testUpload.txt')),
+            $hashResult
+        );
+        // cleanup
+        $files = $u->getFiles(true);
+        $files[0]->remove();
+    }
+    /**
+     * @test
+     */
+    public function testStreamProcessorFailure() {
+        $_SERVER['REQUEST_METHOD'] = 'post';
+        $u = new FileUploader(__DIR__, ['txt']);
+
+        $u->setStreamProcessor(function(\Generator $chunks, string $destPath) {
+            throw new \RuntimeException('Processing failed');
+        });
+
+        FileUploader::addTestFile('files', ROOT_PATH.'tests'.DS.'tmp'.DS.'testUpload.txt', true);
+        $r = $u->upload();
+        $this->assertFalse($r[0]['uploaded']);
+    }
 }

--- a/tests/WebFiori/Framework/Test/File/UploaderTest.php
+++ b/tests/WebFiori/Framework/Test/File/UploaderTest.php
@@ -230,6 +230,13 @@ class UploaderTest extends TestCase {
     /**
      * @test
      */
+    public function testUploadedFileImplementsFileInterface() {
+        $file = new UploadedFile();
+        $this->assertInstanceOf(\WebFiori\File\FileInterface::class, $file);
+    }
+    /**
+     * @test
+     */
     public function testGetMaxFileSize() {
         $val = ini_get('upload_max_filesize');
         $lastChar = strtoupper($val[strlen($val) - 1]);


### PR DESCRIPTION
## Summary

Complete feature release adding streaming I/O, framework decoupling, and upload enhancements.

## Issues Resolved (21)

### FileInterface Chain
- #66 — Define FileInterface contract
- #67 — File implements FileInterface
- #68 — Verify UploadedFile satisfies FileInterface
- #69 — Type-hint FileInterface in FileUploader API
- #70 — Document FileInterface usage and mocking

### Streaming & Decoupling
- #73 — Define StreamableInterface contract
- #74 — Define ResponseEmitter interface
- #75 — Create FileStream class
- #76 — Decouple from WebFiori framework dependencies
- #45 — Remove tight coupling to App
- #48 — view() no longer calls die()

### Features
- #49 — Add copy() and moveTo() methods
- #83 — Implement copy()/moveTo() using streaming
- #79 — Atomic write support (temp + rename)
- #84 — Streaming upload with hash verification
- #53 — Upload callback hooks
- AbstractUploader base class + StreamingUploader for php://input

### Documentation & Testing
- #64 — Standardize README structure
- #85 — Comprehensive streaming tests
- #86 — Security-focused tests
- New examples: streaming, copy/move, atomic write, streaming upload (with frontend), callbacks

## Testing

146 tests, 357 assertions, 0 failures, 0 skipped.

## Breaking Changes

- `File` no longer imports `WebFiori\Framework\App` or `WebFiori\Http\Response`
- `getResponse()` replaced by `getResponseEmitter()`/`setResponseEmitter()`
- `view()` defaults to `$terminate = false`
- Users relying on auto-detection of `WebFiori\Http\Response` must now explicitly set a `WebFioriEmitter`